### PR TITLE
Limit sktime version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "pandas<2.2.0,>=1.3",  # pandas is the main in-memory data container
   "numba>=0.56",  # numba is used for fast computation throughout
-  "sktime>=0.23.0",
+  "sktime>=0.23.0,<0.30.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
sktime annotator API changed in version 0.30.0. Needs to be updated later.