### PR TITLE
[ENH] Use ruff formatter

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #.idea/
 
 .vscode/
+
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,11 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
-        args: ["--maxkb=1000"]
+        args:
+          - --maxkb=1000
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks
@@ -13,68 +14,21 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
         exclude: "^docs/source/examples/"
-      - id: fix-encoding-pragma
-        args:
-          - --remove
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
     hooks:
-      - id: pyupgrade
-        args:
-          - --py38-plus
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort
-
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-        language_version: python3
-        # args: [--line-length 79]
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        exclude: docs/conf.py
-        additional_dependencies: [flake8-bugbear, flake8-print]
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]
 
   - repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"
     hooks:
       - id: check-manifest
         stages: [manual]
-
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
-    hooks:
-      - id: nbqa-black
-        args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
-        additional_dependencies: [black==22.3.0]
-      - id: nbqa-isort
-        args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
-        additional_dependencies: [isort==5.6.4]
-      - id: nbqa-flake8
-        args: [--nbqa-dont-skip-bad-cells, "--extend-ignore=E402,E203"]
-        additional_dependencies: [flake8==3.8.3]
-
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        args: ["--config=setup.cfg"]
-        exclude: |
-          (?x)^(
-            build_tools/.*|
-            interactive/.*
-          )$
 
   # We use the Python version instead of the original version which seems to require Docker
   # https://github.com/koalaman/shellcheck-precommit

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A playground for now.
 ```sh
 pip install skchange
 ```
-Requires Python >= 3.8, < 3.13.
+Requires Python >= 3.9, < 3.13.
 
 ## Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ all_extras = [
 
 # dev - the developer dependency set, install via "pip install skchange[dev]"
 dev = [
-    "black",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,12 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 dependencies = [
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "pandas<2.2.0,>=1.3",  # pandas is the main in-memory data container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dev = [
     "pytest-cov",
 ]
 
-
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>61"]
@@ -67,5 +66,87 @@ requires = ["setuptools>61"]
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
 
-[tool.black]
+# ruff setting adapted from sktime
+[tool.ruff]
 line-length = 88
+exclude = [".git"]
+target-version = "py39"
+extend-include = ["*.ipynb"]
+
+[tool.ruff.lint]
+select = [
+  # https://pypi.org/project/pycodestyle
+  "D",
+  "E",
+  "W",
+  # https://pypi.org/project/pyflakes
+  "F",
+  # https://pypi.org/project/flake8-bandit
+  "S",
+  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+  "UP",
+  "I002",    # Missing required imports
+  "UP008",   # Super calls with redundant arguments passed.
+  "G010",    # Deprecated log warn.
+  "PLR1722", # Use sys.exit() instead of exit() and quit().
+  "PT014",   # pytest-duplicate-parametrize-test-cases.
+  "PT006",   # Checks for the type of parameter names passed to pytest.mark.parametrize.
+  "PT007",   # Checks for the type of parameter values passed to pytest.mark.parametrize.
+  "PT018",   # Checks for assertions that combine multiple independent condition
+  "RUF001", # Checks for non unicode string literals
+  "RUF002", # Checks for non unicode string literals
+  "RUF003", # Checks for non unicode string literals
+]
+extend-select = [
+  "I", # isort
+  "C4", # https://pypi.org/project/flake8-comprehensions
+]
+ignore=[
+  "E203", # Whitespace-before-punctuation.
+  "E402", # Module-import-not-at-top-of-file.
+  "E731", # Do not assign a lambda expression, use a def.
+  "RET504", # Unnecessary variable assignment before `return` statement.
+  "S101", # Use of `assert` detected.
+  "RUF100", # https://docs.astral.sh/ruff/rules/unused-noqa/
+  "C408", # Unnecessary dict call - rewrite as a literal.
+  "UP031", # Use format specifier instead of %
+  "S102", # Use of excec
+  "C414", # Unnecessary `list` call within `sorted()`
+  "S301", # pickle and modules that wrap it can be unsafe
+  "C416", # Unnecessary list comprehension - rewrite as a generator
+  "S310", # Audit URL open for permitted schemes
+  "S202", # Uses of `tarfile.extractall()`
+  "S307", # Use of possibly insecure function
+  "C417", # Unnecessary `map` usage (rewrite using a generator expression)
+  "S605", # Starting a process with a shell, possible injection detected
+  "E741", # Ambiguous variable name
+  "S107", # Possible hardcoded password
+  "S105", # Possible hardcoded password
+  "PT018", # Checks for assertions that combine multiple independent condition
+  "S602", # sub process call with shell=True unsafe
+  "C419", # Unnecessary list comprehension, some are flagged yet are not
+  "C409", # Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+  "S113", # Probable use of httpx call withour timeout
+]
+allowed-confusables=["σ"]
+
+[tool.ruff.lint.per-file-ignores]
+
+"setup.py" = ["S101"]
+"**/__init__.py" = [
+  "F401", # unused import
+]
+"**/tests/**" = [
+  "D",
+  "S605",  # Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+  "S607",  # Starting a process with a partial executable path
+  "RET504",  # todo:Unnecessary variable assignment before `return` statement
+  "PT004",  # Fixture `tmpdir_unittest_fixture` does not return anything, add leading underscore
+  "PT011",  # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+  "PT012",  # `pytest.raises()` block should contain a single simple statement
+  "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
+  "PT006" # Checks for the type of parameter names passed to pytest.mark.parametrize.
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,6 @@
 [aliases]
 test = pytest
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-
 [tool:pytest]
 # ignore certain folders and pytest warnings
 addopts =
@@ -26,15 +22,6 @@ filterwarnings =
     ignore:numpy.dtype size changed
     ignore:numpy.ufunc size changed
 
-[flake8]
-# Default flake8 3.5 ignored flags
-ignore = E121, E123, E126, E226, E24, E704, W503, W504
-# inline with Black code formatter
-max-line-length = 88
-extend-ignore =
-    # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203
-
 [metadata]
 description_file = README.md
 long_description_content_type = text/markdown
@@ -53,10 +40,3 @@ ignore =
     # CONTRIBUTING.md
     # *.yaml
     # *.yml
-
-[isort]
-profile = black
-
-[pydocstyle]
-convention = numpy
-match = (?!test_).*\.py

--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -1,8 +1,9 @@
 """The collective and point anomalies (CAPA) algorithm."""
+
 __author__ = ["mtveten"]
 __all__ = ["Capa"]
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -25,7 +26,7 @@ def run_capa(
     point_alpha: float,
     min_segment_length: int,
     max_segment_length: int,
-) -> Tuple[np.ndarray, List[Tuple[int, int]], List[Tuple[int, int]]]:
+) -> tuple[np.ndarray, list[tuple[int, int]], list[tuple[int, int]]]:
     params = saving_init_func(X)
     collective_betas = np.zeros(1)
     point_betas = np.zeros(1)
@@ -106,7 +107,7 @@ class Capa(BaseSeriesAnnotator):
 
     def __init__(
         self,
-        saving: Union[str, Tuple[Callable, Callable]] = "mean",
+        saving: Union[str, tuple[Callable, Callable]] = "mean",
         collective_penalty_scale: float = 2.0,
         point_penalty_scale: float = 2.0,
         min_segment_length: int = 2,
@@ -130,7 +131,7 @@ class Capa(BaseSeriesAnnotator):
         check_larger_than(2, min_segment_length, "min_segment_length")
         check_larger_than(min_segment_length, max_segment_length, "max_segment_length")
 
-    def _get_penalty_components(self, X: pd.DataFrame) -> Tuple[np.ndarray, float]:
+    def _get_penalty_components(self, X: pd.DataFrame) -> tuple[np.ndarray, float]:
         # TODO: Add penalty tuning.
         # if self.tune:
         #     return self._tune_threshold(X)

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -3,7 +3,7 @@
 __author__ = ["mtveten"]
 __all__ = ["CircularBinarySegmentation"]
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -25,7 +25,7 @@ def greedy_anomaly_selection(
     starts: np.ndarray,
     ends: np.ndarray,
     threshold: float,
-) -> List[Tuple[int, int]]:
+) -> list[tuple[int, int]]:
     scores = scores.copy()
     anomalies = []
     while np.any(scores > threshold):
@@ -41,7 +41,7 @@ def greedy_anomaly_selection(
 @njit
 def make_anomaly_intervals(
     interval_start: int, interval_end: int, min_segment_length: int = 1
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     starts = []
     ends = []
     for i in range(interval_start + 1, interval_end - min_segment_length + 2):
@@ -62,7 +62,7 @@ def run_circular_binseg(
     min_segment_length: int,
     max_interval_length: int,
     growth_factor: float,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     starts, ends = make_seeded_intervals(
         X.shape[0],
         2 * min_segment_length,
@@ -108,7 +108,7 @@ class CircularBinarySegmentation(BaseSeriesAnnotator):
 
     Parameters
     ----------
-    score: str, Tuple[Callable, Callable], optional (default="mean")
+    score: str, tuple[Callable, Callable], optional (default="mean")
         Test statistic to use for changepoint detection.
         * If "mean", the difference-in-mean statistic is used,
         * If "var", the difference-in-variance statistic is used,
@@ -152,7 +152,7 @@ class CircularBinarySegmentation(BaseSeriesAnnotator):
     References
     ----------
     .. [1] Olshen, A. B., Venkatraman, E. S., Lucito, R., & Wigler, M. (2004). Circular
-    binary segmentation for the analysis of array‐based DNA copy number data.
+    binary segmentation for the analysis of array-based DNA copy number data.
     Biostatistics, 5(4), 557-572.
 
     Examples
@@ -178,7 +178,7 @@ class CircularBinarySegmentation(BaseSeriesAnnotator):
 
     def __init__(
         self,
-        score: Union[str, Tuple[Callable, Callable]] = "mean",
+        score: Union[str, tuple[Callable, Callable]] = "mean",
         threshold_scale: Optional[float] = 2.0,
         level: float = 1e-8,
         min_segment_length: int = 5,

--- a/skchange/anomaly_detectors/moscore_anomaly.py
+++ b/skchange/anomaly_detectors/moscore_anomaly.py
@@ -3,7 +3,7 @@
 __author__ = ["mtveten"]
 __all__ = ["MoscoreAnomaly"]
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,7 @@ def run_moscore_anomaly(
     left_bandwidth: int,
     right_bandwidth: int,
     threshold: float,
-) -> Tuple[List[Tuple[int, int]], np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[list[tuple[int, int]], np.ndarray, np.ndarray, np.ndarray]:
     n = len(X)
     starts = tuple(
         np.arange(left_bandwidth, n - k - right_bandwidth)
@@ -68,7 +68,7 @@ class MoscoreAnomaly(BaseSeriesAnnotator):
 
     Parameters
     ----------
-    score: str, Tuple[Callable, Callable], optional (default="mean")
+    score: str, tuple[Callable, Callable], optional (default="mean")
         Test statistic to use for changepoint detection.
         * If "mean", the difference-in-mean statistic is used,
         * If "var", the difference-in-variance statistic is used,
@@ -138,7 +138,7 @@ class MoscoreAnomaly(BaseSeriesAnnotator):
 
     def __init__(
         self,
-        score: Union[str, Tuple[Callable, Callable]] = "mean",
+        score: Union[str, tuple[Callable, Callable]] = "mean",
         min_anomaly_length: int = 2,
         max_anomaly_length: int = 100,
         left_bandwidth: int = 50,

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -3,7 +3,7 @@
 __author__ = ["mtveten"]
 __all__ = ["Mvcapa"]
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ from skchange.utils.validation.parameters import check_larger_than
 
 def dense_capa_penalty(
     n: int, p: int, n_params: int = 1, scale: float = 1.0
-) -> Tuple[float, np.ndarray]:
+) -> tuple[float, np.ndarray]:
     """Penalty function for dense anomalies in CAPA.
 
     Parameters
@@ -47,7 +47,7 @@ def dense_capa_penalty(
 
 def sparse_capa_penalty(
     n: int, p: int, n_params: int = 1, scale: float = 1.0
-) -> Tuple[float, np.ndarray]:
+) -> tuple[float, np.ndarray]:
     """Penalty function for sparse anomalies in CAPA.
 
     Parameters
@@ -76,7 +76,7 @@ def sparse_capa_penalty(
 
 def intermediate_capa_penalty(
     n: int, p: int, n_params: int = 1, scale: float = 1.0
-) -> Tuple[float, np.ndarray]:
+) -> tuple[float, np.ndarray]:
     """Penalty function balancing both dense and sparse anomalies in CAPA.
 
     Parameters
@@ -118,7 +118,7 @@ def intermediate_capa_penalty(
 
 def combined_capa_penalty(
     n: int, p: int, n_params: int = 1, scale: float = 1.0
-) -> Tuple[float, np.ndarray]:
+) -> tuple[float, np.ndarray]:
     """Pointwise minimum of dense, sparse and intermediate penalties in CAPA.
 
     Parameters
@@ -189,7 +189,7 @@ def capa_penalty_factory(penalty: Union[str, Callable] = "combined") -> Callable
 @njit
 def get_anomalies(
     anomaly_starts: np.ndarray,
-) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
     collective_anomalies = []
     point_anomalies = []
     i = anomaly_starts.size - 1
@@ -230,10 +230,10 @@ def penalise_savings(
 def find_affected_components(
     params: Union[np.ndarray, tuple],
     saving_func: Callable,
-    anomalies: List[Tuple[int, int]],
+    anomalies: list[tuple[int, int]],
     alpha: float,
     betas: np.ndarray,
-) -> List[Tuple[int, int, np.ndarray]]:
+) -> list[tuple[int, int, np.ndarray]]:
     new_anomalies = []
     for start, end in anomalies:
         saving = saving_func(params, np.array([start]), np.array([end]))[0]
@@ -251,7 +251,7 @@ def optimise_savings(
     next_savings: np.ndarray,
     alpha: float,
     betas: np.ndarray,
-) -> Tuple[float, int, np.ndarray]:
+) -> tuple[float, int, np.ndarray]:
     penalised_saving = penalise_savings(next_savings, alpha, betas)
     candidate_savings = opt_savings[starts] + penalised_saving
     argmax = np.argmax(candidate_savings)
@@ -270,7 +270,7 @@ def run_base_capa(
     point_betas: np.ndarray,
     min_segment_length: int,
     max_segment_length: int,
-) -> Tuple[np.ndarray, List[Tuple[int, int]], List[Tuple[int, int]]]:
+) -> tuple[np.ndarray, list[tuple[int, int]], list[tuple[int, int]]]:
     n = X.shape[0]
     opt_savings = np.zeros(n + 1)
     # Store the optimal start and affected components of an anomaly for each t.
@@ -326,8 +326,8 @@ def run_mvcapa(
     point_betas: np.ndarray,
     min_segment_length: int,
     max_segment_length: int,
-) -> Tuple[
-    np.ndarray, List[Tuple[int, int, np.ndarray]], List[Tuple[int, int, np.ndarray]]
+) -> tuple[
+    np.ndarray, list[tuple[int, int, np.ndarray]], list[tuple[int, int, np.ndarray]]
 ]:
     params = saving_init_func(X)
     opt_savings, collective_anomalies, point_anomalies = run_base_capa(
@@ -418,7 +418,7 @@ class Mvcapa(BaseSeriesAnnotator):
 
     def __init__(
         self,
-        saving: Union[str, Tuple[Callable, Callable]] = "mean",
+        saving: Union[str, tuple[Callable, Callable]] = "mean",
         collective_penalty: Union[str, Callable] = "combined",
         collective_penalty_scale: float = 2.0,
         point_penalty: Union[str, Callable] = "sparse",
@@ -446,7 +446,7 @@ class Mvcapa(BaseSeriesAnnotator):
         check_larger_than(2, min_segment_length, "min_segment_length")
         check_larger_than(min_segment_length, max_segment_length, "max_segment_length")
 
-    def _get_penalty_components(self, X: pd.DataFrame) -> Tuple[np.ndarray, float]:
+    def _get_penalty_components(self, X: pd.DataFrame) -> tuple[np.ndarray, float]:
         # TODO: Add penalty tuning.
         # if self.tune:
         #     return self._tune_threshold(X)

--- a/skchange/anomaly_detectors/utils.py
+++ b/skchange/anomaly_detectors/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for anomaly detection."""
 
-from typing import List, Tuple, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -8,15 +8,15 @@ import pandas as pd
 
 def merge_anomalies(
     collective_anomalies: Union[
-        List[Tuple[int, int]], List[Tuple[int, int, np.ndarray]]
+        list[tuple[int, int]], list[tuple[int, int, np.ndarray]]
     ] = None,
     point_anomalies: Union[
-        List[int],
-        List[Tuple[int, int]],
-        List[Tuple[int, np.ndarray]],
-        List[Tuple[int, int, np.ndarray]],
+        list[int],
+        list[tuple[int, int]],
+        list[tuple[int, np.ndarray]],
+        list[tuple[int, int, np.ndarray]],
     ] = None,
-) -> List[Tuple[int, int, np.ndarray]]:
+) -> list[tuple[int, int, np.ndarray]]:
     """Merge collective and point anomalies into a single list of intervals.
 
     Parameters
@@ -57,7 +57,7 @@ def merge_anomalies(
 
 
 def anomalies_to_labels(
-    anomalies: List[Tuple[int, int]], n: int, p: int = None
+    anomalies: list[tuple[int, int]], n: int, p: int = None
 ) -> np.ndarray:
     """Convert anomaly indices to labels.
 
@@ -95,8 +95,8 @@ def format_anomaly_output(
     fmt: str,
     labels: str,
     X_index: pd.Index,
-    collective_anomalies: List[tuple] = None,
-    point_anomalies: List[tuple] = None,
+    collective_anomalies: list[tuple] = None,
+    point_anomalies: list[tuple] = None,
     scores: Union[pd.Series, pd.DataFrame] = None,
 ) -> pd.Series:
     """Format the predict method output of change detectors.
@@ -150,8 +150,8 @@ def format_multivariate_anomaly_output(
     labels: str,
     X_index: pd.Index,
     X_columns: pd.Index,
-    collective_anomalies: List[dict] = None,
-    point_anomalies: List[dict] = None,
+    collective_anomalies: list[dict] = None,
+    point_anomalies: list[dict] = None,
     scores: Union[pd.Series, pd.DataFrame] = None,
 ) -> pd.Series:
     """Format the predict method output of change detectors.

--- a/skchange/change_detectors/moscore.py
+++ b/skchange/change_detectors/moscore.py
@@ -3,7 +3,7 @@
 __author__ = ["mtveten"]
 __all__ = ["Moscore"]
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -38,7 +38,7 @@ def moscore_transform(
     score_f: Callable,
     score_init_f: Callable,
     bandwidth: int,
-) -> Tuple[list, np.ndarray]:
+) -> tuple[list, np.ndarray]:
     n = len(X)
     splits = np.arange(bandwidth - 1, n - bandwidth)
     starts = splits - bandwidth + 1
@@ -59,7 +59,7 @@ class Moscore(BaseSeriesAnnotator):
 
     Parameters
     ----------
-    score: str, Tuple[Callable, Callable], optional (default="mean")
+    score: str, tuple[Callable, Callable], optional (default="mean")
         Test statistic to use for changepoint detection.
         * If "mean", the difference-in-mean statistic is used,
         * If "var", the difference-in-variance statistic is used,
@@ -120,7 +120,7 @@ class Moscore(BaseSeriesAnnotator):
 
     def __init__(
         self,
-        score: Union[str, Tuple[Callable, Callable]] = "mean",
+        score: Union[str, tuple[Callable, Callable]] = "mean",
         bandwidth: int = 30,
         threshold_scale: Optional[float] = 2.0,
         level: float = 0.01,

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -4,7 +4,7 @@ __author__ = ["mtveten"]
 __all__ = ["Pelt"]
 
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -31,7 +31,7 @@ def get_changepoints(prev_cpts: np.ndarray) -> list:
 @njit
 def run_pelt(
     X: np.ndarray, cost_func, cost_init_func, penalty, min_segment_length
-) -> Tuple[np.ndarray, list]:
+) -> tuple[np.ndarray, list]:
     params = cost_init_func(X)
     n = len(X)
 

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -3,7 +3,7 @@
 __author__ = ["mtveten"]
 __all__ = ["SeededBinarySegmentation"]
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ from skchange.utils.validation.parameters import check_in_interval, check_larger
 @njit
 def make_seeded_intervals(
     n: int, min_length: int, max_length: int, growth_factor: float = 1.5
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     starts = [0]  # For numba to be able to compile type.
     ends = [0]  # For numba to be able to compile type.
     step_factor = 1 - 1 / growth_factor
@@ -47,7 +47,7 @@ def greedy_changepoint_selection(
     starts: np.ndarray,
     ends: np.ndarray,
     threshold: float,
-) -> List[int]:
+) -> list[int]:
     scores = scores.copy()
     cpts = []
     while np.any(scores > threshold):
@@ -68,7 +68,7 @@ def run_seeded_binseg(
     min_segment_length: int,
     max_interval_length: int,
     growth_factor: float,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     starts, ends = make_seeded_intervals(
         X.shape[0],
         2 * min_segment_length,
@@ -109,7 +109,7 @@ class SeededBinarySegmentation(BaseSeriesAnnotator):
 
     Parameters
     ----------
-    score: str, Tuple[Callable, Callable], optional (default="mean")
+    score: str, tuple[Callable, Callable], optional (default="mean")
         Test statistic to use for changepoint detection.
         * If "mean", the difference-in-mean statistic is used,
         * If "var", the difference-in-variance statistic is used,
@@ -174,7 +174,7 @@ class SeededBinarySegmentation(BaseSeriesAnnotator):
 
     def __init__(
         self,
-        score: Union[str, Tuple[Callable, Callable]] = "mean",
+        score: Union[str, tuple[Callable, Callable]] = "mean",
         threshold_scale: Optional[float] = 2.0,
         level: float = 1e-8,
         min_segment_length: int = 5,

--- a/skchange/costs/mean_cost.py
+++ b/skchange/costs/mean_cost.py
@@ -1,7 +1,5 @@
 """Gaussian mean likelihood cost function for change point detection."""
 
-from typing import Tuple
-
 import numpy as np
 from numba import njit
 
@@ -10,7 +8,7 @@ from skchange.utils.numba.stats import col_cumsum
 
 
 @njit(cache=True)
-def init_mean_cost(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def init_mean_cost(X: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Precompute sums and weights for mean_cost.
 
     Parameters
@@ -41,7 +39,7 @@ def init_mean_cost(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
 
 @njit(cache=True)
 def mean_cost(
-    precomputed_params: Tuple[np.ndarray, np.ndarray, np.ndarray],
+    precomputed_params: tuple[np.ndarray, np.ndarray, np.ndarray],
     starts: np.ndarray,
     ends: np.ndarray,
 ) -> np.ndarray:
@@ -49,7 +47,7 @@ def mean_cost(
 
     Parameters
     ----------
-    precomputed_params : Tuple[np.ndarray, np.ndarray, np.ndarray]
+    precomputed_params : tuple[np.ndarray, np.ndarray, np.ndarray]
         Precomputed parameters from init_mean_cost.
     starts : np.ndarray
         Start indices of the segments.

--- a/skchange/costs/mean_saving.py
+++ b/skchange/costs/mean_saving.py
@@ -1,7 +1,5 @@
 """Mean saving for CAPA type anomaly detection."""
 
-from typing import Tuple
-
 import numpy as np
 from numba import njit
 
@@ -10,7 +8,7 @@ from skchange.utils.numba.stats import col_cumsum
 
 
 @njit(cache=True)
-def init_mean_saving(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def init_mean_saving(X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Precompute sums and weights for mean_cost.
 
     Parameters
@@ -36,7 +34,7 @@ def init_mean_saving(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
 
 @njit(cache=True)
 def mean_saving(
-    precomputed_params: Tuple[np.ndarray, np.ndarray],
+    precomputed_params: tuple[np.ndarray, np.ndarray],
     starts: np.ndarray,
     ends: np.ndarray,
 ) -> np.ndarray:
@@ -44,7 +42,7 @@ def mean_saving(
 
     Parameters
     ----------
-    precomputed_params : Tuple[np.ndarray, np.ndarray]
+    precomputed_params : tuple[np.ndarray, np.ndarray]
         Precomputed parameters from init_mean_saving.
     starts : np.ndarray
         Start indices of the segments.

--- a/skchange/datasets/generate.py
+++ b/skchange/datasets/generate.py
@@ -1,7 +1,7 @@
 """Data generators."""
 
 from numbers import Number
-from typing import List, Tuple, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -68,9 +68,9 @@ def generate_teeth_data(
 
 def generate_anomalous_data(
     n: int = 100,
-    anomalies: Union[Tuple[int, int], List[Tuple[int, int]]] = (71, 80),
-    means: Union[float, List[float], List[np.ndarray]] = 3.0,
-    variances: Union[float, List[float], List[np.ndarray]] = 1.0,
+    anomalies: Union[tuple[int, int], list[tuple[int, int]]] = (71, 80),
+    means: Union[float, list[float], list[np.ndarray]] = 3.0,
+    variances: Union[float, list[float], list[np.ndarray]] = 1.0,
     random_state: int = None,
 ) -> pd.DataFrame:
     """
@@ -94,7 +94,7 @@ def generate_anomalous_data(
     -------
         pd.DataFrame: DataFrame with generate_teeth_data-shaped segments.
     """
-    if isinstance(anomalies, Tuple):
+    if isinstance(anomalies, tuple):
         anomalies = [anomalies]
     if isinstance(means, Number):
         means = [means]

--- a/skchange/scores/mean_score.py
+++ b/skchange/scores/mean_score.py
@@ -1,7 +1,5 @@
 """Test statistic for differences in the mean."""
 
-from typing import Tuple
-
 import numpy as np
 from numba import njit
 
@@ -9,7 +7,7 @@ from skchange.utils.numba.stats import col_cumsum
 
 
 @njit(cache=True)
-def init_mean_score(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def init_mean_score(X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Precompute sums for mean_score.
 
     Parameters

--- a/skchange/scores/meanvar_score.py
+++ b/skchange/scores/meanvar_score.py
@@ -1,7 +1,5 @@
 """Test statistic for differences in the mean and/or variance."""
 
-from typing import Tuple
-
 import numpy as np
 from numba import njit
 
@@ -10,7 +8,7 @@ from skchange.utils.numba.stats import col_cumsum
 
 
 @njit(cache=True)
-def init_meanvar_score(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def init_meanvar_score(X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Precompute sums and squared sums for 'meanvar_score'.
 
     Parameters

--- a/skchange/scores/score_factory.py
+++ b/skchange/scores/score_factory.py
@@ -14,7 +14,7 @@ Recipe for adding new scores:
 
 """
 
-from typing import Callable, Tuple, Union
+from typing import Callable, Union
 
 from numba.extending import is_jitted
 
@@ -29,12 +29,12 @@ VALID_CHANGE_SCORES = ["mean", "meanvar"]
 VALID_ANOMALY_SCORES = ["mean", "meanvar"]
 
 
-def score_factory(score: Union[str, Tuple[Callable, Callable]]):
+def score_factory(score: Union[str, tuple[Callable, Callable]]):
     """Return score function and its initializer.
 
     Parameters
     ----------
-    score: str, Tuple[Callable, Callable]
+    score: str, tuple[Callable, Callable]
         Test statistic to use for changepoint detection.
         * If "mean", the difference-in-mean statistic is used,
         * If "meanvar", the difference-in-mean-and-variance statistic is used,
@@ -66,12 +66,12 @@ def score_factory(score: Union[str, Tuple[Callable, Callable]]):
         raise ValueError(message)
 
 
-def anomaly_score_factory(score: Union[str, Tuple[Callable, Callable]]):
+def anomaly_score_factory(score: Union[str, tuple[Callable, Callable]]):
     """Return anomaly score function and its initializer.
 
     Parameters
     ----------
-    score: str, Tuple[Callable, Callable]
+    score: str, tuple[Callable, Callable]
         Test statistic to use for anomaly detection.
         * If "mean", the difference-in-mean statistic is used,
         * If a tuple, it must contain two functions: The first function is the scoring


### PR DESCRIPTION
- Use ruff rather than black as formatter.
- Update python version to >=3.9
- Format files to adhere to ruff requirements:
   * Typing lists and tuples