### PR TITLE
fix: change "var" to "meanvar" in docs

### DIFF
--- a/skchange/change_detectors/moscore.py
+++ b/skchange/change_detectors/moscore.py
@@ -61,7 +61,7 @@ class Moscore(ChangeDetector):
     score: str, tuple[Callable, Callable], optional (default="mean")
         Test statistic to use for changepoint detection.
         * If "mean", the difference-in-mean statistic is used,
-        * If "var", the difference-in-variance statistic is used,
+        * If "meanvar", the difference-in-variance statistic is used,
         * If a tuple, it must contain two functions: The first function is the scoring
         function, which takes in the output of the second function as its first
         argument, and start, end and split indices as the second, third and fourth


### PR DESCRIPTION
"var" raises a `ValueError`:

```python
ValueError: score=var not recognized. Must be one of mean, meanvar or a tuple of two numba jitted functions.
```

This PR is just a quickfix for the docs. Not sure if meanvar works as intended.