### PR TITLE
fix: use same code-quality test as sktime

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,20 +2,23 @@ name: tests
 on: [push, pull_request]
 jobs:
   code-quality:
+    name: code-quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-      - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+      - name: repository checkout step
+        uses: actions/checkout@v4
+      - name: python environment step
+        uses: actions/setup-python@v5
         with:
-          output: " "
-      - name: List changed files
-        run: echo '${{ steps.file_changes.outputs.files}}'
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
-      - name: Check for missing init files
+          python-version: "3.11"
+      - name: install pre-commit
+        run: python3 -m pip install pre-commit
+      - id: changed-files
+        name: identify modified files
+        uses: tj-actions/changed-files@v45
+      - name: run pre-commit hooks on modified files
+        run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
+      - name: check missing __init__ files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 


### PR DESCRIPTION
Use code-quality CI test from sktime. The previous solution with trilom always caused an error upon first commit in a new brnach.