### PR TITLE
Task/mean cov pelt cost: Add support for multivariate Gaussian negative log likelihood cost

### DIFF
--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -36,7 +36,10 @@ def run_pelt(
 
     starts = np.array((), dtype=np.int64)  # Evolving set of admissible segment starts.
     init_starts = np.zeros(min_segment_length - 1, dtype=np.int64)
-    init_ends = np.arange(min_segment_length - 1)
+
+    # Start at a segment of length `min_segment_length`, incrementing by 1 from there.
+    init_ends = np.arange(min_segment_length - 1, 2*(min_segment_length - 1))
+
     opt_cost = np.zeros(n + 1) - penalty
     opt_cost[1:min_segment_length] = cost_func(params, init_starts, init_ends)
 

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -38,7 +38,7 @@ def run_pelt(
     init_starts = np.zeros(min_segment_length - 1, dtype=np.int64)
 
     # Start at a segment of length `min_segment_length`, incrementing by 1 from there.
-    init_ends = np.arange(min_segment_length - 1, 2*(min_segment_length - 1))
+    init_ends = np.arange(min_segment_length - 1, 2 * (min_segment_length - 1))
 
     opt_cost = np.zeros(n + 1) - penalty
     opt_cost[1:min_segment_length] = cost_func(params, init_starts, init_ends)

--- a/skchange/costs/cost_factory.py
+++ b/skchange/costs/cost_factory.py
@@ -21,6 +21,7 @@ from typing import Callable, Union
 from numba.extending import is_jitted
 
 from skchange.costs.mean_cost import init_mean_cost, mean_cost
+from skchange.costs.mean_cov_cost import init_mean_cov_cost, mean_cov_cost
 
 VALID_COSTS = ["mean"]
 
@@ -34,6 +35,7 @@ def cost_factory(cost: Union[str, tuple[Callable, Callable]]):
         Name of cost function to use for changepoint detection.
 
         * `"mean"`: The Gaussian mean likelihood cost is used.
+        * `"mean_cov"`: The Gaussian mean and covariance likelihood cost is used.
         * If a tuple, it must contain two numba jitted functions:
 
             1. The first function is the cost function, which takes three arguments:
@@ -65,6 +67,8 @@ def cost_factory(cost: Union[str, tuple[Callable, Callable]]):
     """
     if cost == "mean":
         return mean_cost, init_mean_cost
+    elif cost == "mean_cov":
+        return mean_cov_cost, init_mean_cov_cost
     elif len(cost) == 2 and all([is_jitted(s) for s in cost]):
         return cost[0], cost[1]
     else:

--- a/skchange/costs/cost_factory.py
+++ b/skchange/costs/cost_factory.py
@@ -23,7 +23,7 @@ from numba.extending import is_jitted
 from skchange.costs.mean_cost import init_mean_cost, mean_cost
 from skchange.costs.mean_cov_cost import init_mean_cov_cost, mean_cov_cost
 
-VALID_COSTS = ["mean"]
+VALID_COSTS = ["mean", "mean_cov"]
 
 
 def cost_factory(cost: Union[str, tuple[Callable, Callable]]):

--- a/skchange/costs/mean_cov_cost.py
+++ b/skchange/costs/mean_cov_cost.py
@@ -85,8 +85,6 @@ def mean_cov_cost(
     num_starts = len(starts)
     costs = np.zeros(num_starts)
 
-    # Implicitly expect a certain dimension on 'starts' and 'ends'...
-
     for i in range(num_starts):
         segment_mv_ll = gaussian_ll_at_mle_for_segment(X, starts[i], ends[i])
         costs[i] = -segment_mv_ll

--- a/skchange/costs/mean_cov_cost.py
+++ b/skchange/costs/mean_cov_cost.py
@@ -1,0 +1,93 @@
+"""Gaussian mean likelihood cost function for change point detection."""
+
+__author__ = ["johannvk"]
+
+import numpy as np
+from numba import njit
+
+from skchange.scores.mean_cov_score import _mean_cov_log_det_term
+
+
+@njit(cache=True)
+def init_mean_cov_cost(X: np.ndarray) -> np.ndarray:
+    """Pass on the data matrix for the cost function."""
+    return X
+
+
+@njit(cache=True)
+def gaussian_ll_at_mle_for_segment(
+    X: np.ndarray,
+    start: int,
+    end: int,
+) -> float:
+    """Calculate the Gaussian log likelihood at the MLE for a segment.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Data matrix. Rows are observations and columns are variables.
+    start : int
+        Start index of the segment.
+    end : int
+        End index of the segment.
+    split : int
+        Split index of the segment.
+
+    Returns
+    -------
+    mv_ll_at_mle : float
+        Log likelihood of the inclusive interval
+        [start, end] in the data matrix X,
+        evaluated at the maximum likelihood parameter
+        estimates for the mean and covariance matrix.
+    """
+    if not end > start:
+        raise ValueError(
+            f"The 'end={end}' argument must be larger than 'start={start}'."
+            " Cannot compute a covariance matrix from a single observation."
+        )
+
+    n = end - start + 1
+    p = X.shape[1]
+
+    n_times_log_det_cov = _mean_cov_log_det_term(X, start, end)
+    mv_ll_at_mle = -((n * p) / 2) * np.log(2 * np.pi) - n_times_log_det_cov / 2.0
+
+    # Subtract log(exp(Quadratic-form)) = p * n / 2, at MLE.
+    mv_ll_at_mle -= (1 / 2) * p * n
+
+    return mv_ll_at_mle
+
+
+@njit(cache=True)
+def mean_cov_cost(
+    precomputed_params: np.ndarray,
+    starts: np.ndarray,
+    ends: np.ndarray,
+) -> np.ndarray:
+    """Calculate the Gaussian log likelihood cost for each segment.
+
+    Parameters
+    ----------
+    precomputed_params : np.ndarray
+        Precomputed parameters from `init_mean_cov_cost`.
+    starts : np.ndarray
+        Start indices of the segments.
+    ends : np.ndarray
+        End indices of the segments.
+
+    Returns
+    -------
+    costs : np.ndarray
+        Costs of the [start, end] segments, i.e., negative log likelihoods.
+    """
+    X = precomputed_params
+    num_starts = len(starts)
+    costs = np.zeros(num_starts)
+
+    # Implicitly expect a certain dimension on 'starts' and 'ends'...
+
+    for i in range(num_starts):
+        segment_mv_ll = gaussian_ll_at_mle_for_segment(X, starts[i], ends[i])
+        costs[i] = -segment_mv_ll
+    return costs

--- a/skchange/costs/tests/test_mean_cov_cost.py
+++ b/skchange/costs/tests/test_mean_cov_cost.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+from scipy.stats import multivariate_normal
+
+from skchange.costs import cost_factory
+
+
+def analytical_mv_ll_at_mle(X: np.ndarray):
+    """
+    Calculate the analytical multivariate log-likelihood at the MLE.
+
+    Parameters
+    ----------
+    X : `np.ndarray`
+        2D array.
+
+    Returns
+    -------
+    ll : `float`
+        Log-likelihood.
+    """
+    n = X.shape[0]
+    p = X.shape[1]
+
+    # MLE:
+    sigma = np.cov(X, rowvar=False, ddof=0).reshape(p, p)
+
+    # Log-likelihood:
+    det_sign, logdet_sigma = np.linalg.slogdet(sigma)
+    if det_sign <= 0:
+        raise ValueError("Covariance matrix is not positive definite.")
+
+    ll = 0.0
+    ll = -((n * p) / 2) * np.log(2 * np.pi) - (n / 2) * logdet_sigma
+    ll -= (1 / 2) * p * n
+
+    return ll
+
+
+@pytest.mark.parametrize("n, p, seed", [
+    (50, 1, 4125),
+    (50, 3, 4125),
+    (100, 1, 4125),
+    (100, 3, 4125),
+    (50, 1, 2125),
+    (50, 3, 2125),
+    (100, 1, 2125),
+    (100, 3, 2125)
+])
+def test_mean_cov_cost(n: int, p: int, seed: int):
+    """Test mean covariance cost."""
+    # Generate data:
+    np.random.seed(seed)
+    X = np.random.randn(n, p)
+
+    mean_cov_cost_fn, mean_cov_init_cost_fn = cost_factory("mean_cov")
+    mean_cov_cost_array = mean_cov_cost_fn(mean_cov_init_cost_fn(X), [0], [n - 1])
+    mean_cov_cost = mean_cov_cost_array[0]
+
+    # Analytical cost using SciPy:
+    mu_X = np.mean(X, axis=0)
+    cov_X = np.cov(X, rowvar=False, ddof=0)
+    mvn_dist = multivariate_normal(mean=mu_X, cov=cov_X)
+    numerical_mle_ll = mvn_dist.logpdf(X).sum()
+    numerical_cost = -numerical_mle_ll
+
+    analytical_mle_ll = analytical_mv_ll_at_mle(X)
+    analytical_cost = -analytical_mle_ll
+
+    assert np.allclose(numerical_mle_ll, analytical_mle_ll)
+    assert np.allclose(numerical_cost, analytical_cost)
+    assert np.allclose(mean_cov_cost, analytical_cost)
+

--- a/skchange/costs/tests/test_mean_cov_cost.py
+++ b/skchange/costs/tests/test_mean_cov_cost.py
@@ -37,16 +37,19 @@ def analytical_mv_ll_at_mle(X: np.ndarray):
     return ll
 
 
-@pytest.mark.parametrize("n, p, seed", [
-    (50, 1, 4125),
-    (50, 3, 4125),
-    (100, 1, 4125),
-    (100, 3, 4125),
-    (50, 1, 2125),
-    (50, 3, 2125),
-    (100, 1, 2125),
-    (100, 3, 2125)
-])
+@pytest.mark.parametrize(
+    "n, p, seed",
+    [
+        (50, 1, 4125),
+        (50, 3, 4125),
+        (100, 1, 4125),
+        (100, 3, 4125),
+        (50, 1, 2125),
+        (50, 3, 2125),
+        (100, 1, 2125),
+        (100, 3, 2125),
+    ],
+)
 def test_mean_cov_cost(n: int, p: int, seed: int):
     """Test mean covariance cost."""
     # Generate data:
@@ -64,10 +67,10 @@ def test_mean_cov_cost(n: int, p: int, seed: int):
     numerical_mle_ll = mvn_dist.logpdf(X).sum()
     numerical_cost = -numerical_mle_ll
 
+    # Analytical cost from theoretical formulae:
     analytical_mle_ll = analytical_mv_ll_at_mle(X)
     analytical_cost = -analytical_mle_ll
 
     assert np.allclose(numerical_mle_ll, analytical_mle_ll)
     assert np.allclose(numerical_cost, analytical_cost)
     assert np.allclose(mean_cov_cost, analytical_cost)
-

--- a/skchange/utils/numba/stats.py
+++ b/skchange/utils/numba/stats.py
@@ -1,5 +1,4 @@
 """Numba-optimized functions for calculating various statistics."""
-
 import numpy as np
 from numba import njit
 


### PR DESCRIPTION
This PR adds support for using the negated log likelihood of the multivariate Gaussian distribution, evaluated at the maximum likelihood estimates for the mean and covariance, as a cost function. 

This PR shares many similarities with the 'mean_cov' score, and reuses some internal functionality from that score used to compute the log-determinant of a covariance matrix.

Additionally, I've added tests for approximate equality between three different ways of computing the mv-normal log likelihood cost. 