### PR TITLE
Task/weak numba dependency

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,5 @@ ignore:
   - "*.yml"
   - "*.yaml"
   - "*.cfg"
+  - "*/tests/*"
+  - "test_*.py"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,14 +23,14 @@ jobs:
         shell: bash
 
   pytests-numba:
-    name: pytests-numba
+    name: Run pytests with numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -44,14 +44,14 @@ jobs:
           pytest --cov=skchange --cov-report=xml --cov-append
 
   pytests-no-numba:
-    name: pytests-no-numba
+    name: Run pytests without numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -60,14 +60,17 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov=skchange --cov-report=xml --cov-append
+      # - name: Upload coverage reports to Codecov
+      #   uses: codecov/codecov-action@v3
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  upload-code-cov:
+    name: Upload-coverage-reports-to-Codecov
+    needs: [pytests-numba, pytests-no-numba]
+    runs-on: ubuntu-latest
+    steps:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  upload-code-cov:
-    - needs: [pytests-numba, pytests-no-numba]
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  pytests:
+  pytests-no-numba:
     name: pytests-no-numba
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,12 +41,7 @@ jobs:
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Test with pytest
         run: |
-          pytest --cov --cov-report=xml
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v3
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
+          pytest --cov=skchange --cov-report=xml --cov-append
 
   pytests-no-numba:
     name: pytests-no-numba
@@ -64,8 +59,15 @@ jobs:
           python -m pip install pytest
       - name: Test with pytest
         run: |
-          pytest --cov --cov-report=xml --cov-append
+          pytest --cov=skchange --cov-report=xml --cov-append
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  upload-code-cov:
+    needs: [pytests-numba, pytests-no-numba]
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,10 +42,10 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov --cov-report=xml
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # - name: Upload coverage reports to Codecov
+      #   uses: codecov/codecov-action@v3
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 
   pytests-no-numba:
@@ -64,7 +64,7 @@ jobs:
           python -m pip install pytest
       - name: Test with pytest
         run: |
-          pytest --cov --cov-report=xml
+          pytest --cov --cov-report=xml --cov-append
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
 
   pytests:
-    # name: pytests-with-numba
+    name: pytests-with-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[dev,numba]
           python -m pip install pytest
-      - name: Disable numba JIT
         run: |
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Test with pytest
@@ -48,7 +47,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pytests-no-numba:
-    # name: pytests-no-numba
+    name: pytests-no-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +60,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[dev]
           python -m pip install pytest
-      - name: Disable numba JIT
       - name: Test with pytest
         run: |
           pytest --cov --cov-report=xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Install Skchange + Numba
         run: |
           python -m pip install .[dev,numba]
+      # Uncomment these lines if you want to disable numba JIT:
       # - name: Disable numba JIT
       #   run: |
       #     echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,8 +22,8 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
-  pytests:
-    name: pytests-with-numba
+  pytests-numba:
+    name: pytests-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[dev,numba]
           python -m pip install pytest
+      - name: Disable numba JIT
         run: |
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Test with pytest
@@ -45,6 +46,7 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 
   pytests-no-numba:
     name: pytests-no-numba

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,10 +41,11 @@ jobs:
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Test with pytest
         run: |
-          pytest --cov=skchange --cov-report=xml --cov-append
+          pytest --cov=skchange --cov-report=xml
 
   pytests-no-numba:
     name: Run pytests without numba
+    needs: pytests-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,10 +61,6 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov=skchange --cov-report=xml --cov-append
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v3
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   upload-code-cov:
     name: Upload-coverage-reports-to-Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
 
   pytests:
-    name: pytests-with-numba
+    # name: pytests-with-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pytests-no-numba:
-    name: pytests-no-numba
+    # name: pytests-no-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Test with pytest
         run: |
-          pytest --cov=skchange --cov-report=xml
+          pytest --cov --cov-report=xml
 
   pytests-no-numba:
     name: Run pytests without numba
@@ -60,7 +60,7 @@ jobs:
           python -m pip install pytest
       - name: Test with pytest
         run: |
-          pytest --cov=skchange --cov-report=xml --cov-append
+          pytest --cov --cov-report=xml --cov-append
 
   upload-code-cov:
     name: Upload-coverage-reports-to-Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,9 +42,9 @@ jobs:
       - name: Install Skchange + Numba
         run: |
           python -m pip install .[dev,numba]
-      - name: Disable numba JIT
-        run: |
-          echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
+      # - name: Disable numba JIT
+      #   run: |
+      #     echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Run pytest - with Numba installed
         run: |
           pytest --cov --cov-report=xml --cov-append

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,8 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
-  pytests-numba:
+  pytests:
+    name: pytests-with-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,8 +47,8 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-
-  pytests-no-numba:
+  pytests:
+    name: pytests-no-numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   upload-code-cov:
-    needs: [pytests-numba, pytests-no-numba]
+    - needs: [pytests-numba, pytests-no-numba]
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,8 +22,8 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
-  pytests-numba:
-    name: Run pytests with numba
+  pytests:
+    name: Run pytests with and without Numba
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,43 +31,59 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Install Python dependencies
+      - name: Install Python dependencies - without Numba
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[dev,numba]
+          python -m pip install .[dev]
           python -m pip install pytest
+      - name: Test with pytest - without Numba
+        run: |
+          pytest --cov --cov-report=xml
+      - name: Install Skchange + Numba
+        run: |
+          python -m pip install .[dev,numba]
       - name: Disable numba JIT
         run: |
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Test with pytest
         run: |
-          pytest --cov --cov-report=xml
-
-  pytests-no-numba:
-    name: Run pytests without numba
-    needs: pytests-numba
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install .[dev]
-          python -m pip install pytest
-      - name: Test with pytest
-        run: |
           pytest --cov --cov-report=xml --cov-append
-
-  upload-code-cov:
-    name: Upload-coverage-reports-to-Codecov
-    needs: [pytests-numba, pytests-no-numba]
-    runs-on: ubuntu-latest
-    steps:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # pytests-no-numba:
+  #   name: Run pytests without numba
+  #   needs: pytests-numba
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.9"
+  #     - name: Install Python dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install .[dev]
+  #         python -m pip install pytest
+  #     - name: Test with pytest
+  #       run: |
+  #         pytest --cov --cov-report=xml --cov-append
+
+  # upload-code-cov:
+  #   name: Upload-coverage-reports-to-Codecov
+  #   needs: [pytests-numba, pytests-no-numba]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check for coverage report files
+  #       run: |
+  #         if [ ! -f coverage.xml ]; then
+  #           echo "No coverage report found!"
+  #           exit 1
+  #         fi
+  #     - name: Upload coverage reports to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       env:
+  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
       #     echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Run pytest - with Numba installed
         run: |
-          pytest --cov --cov-config=.codecov.yml --cov-report=xml --cov-append
+          pytest --cov --cov-report=xml --cov-append
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[dev]
+          python -m pip install .[dev,numba]
           python -m pip install pytest
       - name: Disable numba JIT
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
       #     echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Run pytest - with Numba installed
         run: |
-          pytest --cov --cov-report=xml --cov-append
+          pytest --cov --cov-config=.codecov.yml --cov-report=xml --cov-append
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[dev]
           python -m pip install pytest
-      - name: Test with pytest - without Numba
+      - name: Run pytest - without Numba installed
         run: |
           pytest --cov --cov-report=xml
       - name: Install Skchange + Numba
@@ -45,45 +45,10 @@ jobs:
       - name: Disable numba JIT
         run: |
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
-      - name: Test with pytest
+      - name: Run pytest - with Numba installed
         run: |
           pytest --cov --cov-report=xml --cov-append
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  # pytests-no-numba:
-  #   name: Run pytests without numba
-  #   needs: pytests-numba
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.9"
-  #     - name: Install Python dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install .[dev]
-  #         python -m pip install pytest
-  #     - name: Test with pytest
-  #       run: |
-  #         pytest --cov --cov-report=xml --cov-append
-
-  # upload-code-cov:
-  #   name: Upload-coverage-reports-to-Codecov
-  #   needs: [pytests-numba, pytests-no-numba]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check for coverage report files
-  #       run: |
-  #         if [ ! -f coverage.xml ]; then
-  #           echo "No coverage report found!"
-  #           exit 1
-  #         fi
-  #     - name: Upload coverage reports to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       env:
-  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
-  pytests:
+  pytests-numba:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +38,29 @@ jobs:
       - name: Disable numba JIT
         run: |
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
+      - name: Test with pytest
+        run: |
+          pytest --cov --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
+  pytests-no-numba:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+          python -m pip install pytest
+      - name: Disable numba JIT
       - name: Test with pytest
         run: |
           pytest --cov --cov-report=xml

--- a/docs/source/api_reference/costs.rst
+++ b/docs/source/api_reference/costs.rst
@@ -1,7 +1,7 @@
 .. _costs:
 
-Costs and savings
-=================
+Costs
+=====
 
 Costs
 -----

--- a/interactive/explore_moscore.py
+++ b/interactive/explore_moscore.py
@@ -2,11 +2,11 @@
 
 import numpy as np
 import plotly.express as px
-from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.moscore import Moscore
 from skchange.datasets.generate import add_linspace_outliers, generate_alternating_data
 from skchange.utils.benchmarking.profiler import Profiler
+from skchange.utils.numba.njit import njit
 
 # Simple univariate example
 df = generate_alternating_data(

--- a/interactive/explore_moscore.py
+++ b/interactive/explore_moscore.py
@@ -6,7 +6,7 @@ import plotly.express as px
 from skchange.change_detectors.moscore import Moscore
 from skchange.datasets.generate import add_linspace_outliers, generate_alternating_data
 from skchange.utils.benchmarking.profiler import Profiler
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 
 # Simple univariate example
 df = generate_alternating_data(

--- a/interactive/explore_moscore.py
+++ b/interactive/explore_moscore.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import plotly.express as px
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.moscore import Moscore
 from skchange.datasets.generate import add_linspace_outliers, generate_alternating_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,3 +169,9 @@ allowed-confusables=["σ"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.coverage.run]
+omit = [
+  "*/tests/*",
+  "*/test_*.py"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ requires-python = ">=3.9,<3.13"
 dependencies = [
   "numpy>=1.21",
   "pandas>=1.1",
-  "numba>=0.56",  # numba is used for fast computation throughout
   "sktime>=0.33",
 ]
 
@@ -45,6 +44,11 @@ dependencies = [
 Homepage = "https://skchange.readthedocs.io"
 
 [project.optional-dependencies]
+# numba - numba as an optional dependency, install via "pip install skchange[numba]"
+numba = [
+  "numba>=0.56"
+]
+
 # all_extras - all soft dependencies, install via "pip install skchange[all_extras]"
 all_extras = [
   "optuna>=3.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ numba = [
 all_extras = [
   "optuna>=3.1.1",
   "plotly>=5.13.0",
+  "numba>=0.56",
 ]
 
 # dev - the developer dependency set, install via "pip install skchange[dev]"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ addopts =
     # --cov sktime
     # --cov-report xml
     # --cov-report html
+    --cov-config=pyproject.toml
     # --showlocals
     # --matrixdesign True
     # --only_changed_modules True

--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -11,7 +11,7 @@ import pandas as pd
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.anomaly_detectors.mvcapa import dense_capa_penalty, run_base_capa
 from skchange.costs.saving_factory import saving_factory
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_larger_than
 

--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -7,11 +7,11 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from skchange.utils.numba.njit import njit
 
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.anomaly_detectors.mvcapa import dense_capa_penalty, run_base_capa
 from skchange.costs.saving_factory import saving_factory
+from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_larger_than
 

--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.anomaly_detectors.mvcapa import dense_capa_penalty, run_base_capa

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -11,7 +11,7 @@ import pandas as pd
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.change_detectors.seeded_binseg import make_seeded_intervals
 from skchange.scores.score_factory import anomaly_score_factory
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_in_interval, check_larger_than
 

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.change_detectors.seeded_binseg import make_seeded_intervals

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -7,11 +7,11 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from skchange.utils.numba.njit import njit
 
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.change_detectors.seeded_binseg import make_seeded_intervals
 from skchange.scores.score_factory import anomaly_score_factory
+from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_in_interval, check_larger_than
 

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -11,7 +11,7 @@ from scipy.stats import chi2
 
 from skchange.anomaly_detectors.base import SubsetCollectiveAnomalyDetector
 from skchange.costs.saving_factory import saving_factory
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_larger_than
 

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -7,11 +7,11 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from skchange.utils.numba.njit import njit
 from scipy.stats import chi2
 
 from skchange.anomaly_detectors.base import SubsetCollectiveAnomalyDetector
 from skchange.costs.saving_factory import saving_factory
+from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_larger_than
 

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from numba import njit
+from skchange.utils.numba.njit import njit
 from scipy.stats import chi2
 
 from skchange.anomaly_detectors.base import SubsetCollectiveAnomalyDetector

--- a/skchange/anomaly_detectors/tests/test_anomaly_detectors.py
+++ b/skchange/anomaly_detectors/tests/test_anomaly_detectors.py
@@ -3,8 +3,11 @@
 import pandas as pd
 import pytest
 
-from skchange.anomaly_detectors import ANOMALY_DETECTORS, COLLECTIVE_ANOMALY_DETECTORS
-from skchange.anomaly_detectors import MoscoreAnomaly
+from skchange.anomaly_detectors import (
+    ANOMALY_DETECTORS,
+    COLLECTIVE_ANOMALY_DETECTORS,
+    MoscoreAnomaly,
+)
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.datasets.generate import generate_anomalous_data
 from skchange.scores.mean_score import init_mean_score, mean_anomaly_score

--- a/skchange/anomaly_detectors/tests/test_anomaly_detectors.py
+++ b/skchange/anomaly_detectors/tests/test_anomaly_detectors.py
@@ -4,8 +4,10 @@ import pandas as pd
 import pytest
 
 from skchange.anomaly_detectors import ANOMALY_DETECTORS, COLLECTIVE_ANOMALY_DETECTORS
+from skchange.anomaly_detectors import MoscoreAnomaly
 from skchange.anomaly_detectors.base import CollectiveAnomalyDetector
 from skchange.datasets.generate import generate_anomalous_data
+from skchange.scores.mean_score import init_mean_score, mean_anomaly_score
 
 true_anomalies = [(30, 34), (70, 75)]
 anomaly_data = generate_anomalous_data(
@@ -27,7 +29,7 @@ def test_collective_anomaly_detector_predict(Estimator):
 
 
 @pytest.mark.parametrize("Estimator", COLLECTIVE_ANOMALY_DETECTORS)
-def test_collective_anomaly_detector_transform(Estimator):
+def test_collective_anomaly_detector_transform(Estimator: CollectiveAnomalyDetector):
     """Test collective anomaly detector's transform method (dense output)."""
     detector = Estimator.create_test_instance()
     labels = detector.fit_transform(anomaly_data)
@@ -48,8 +50,34 @@ def test_collective_anomaly_detector_transform(Estimator):
         assert (labels.iloc[start : end + 1] == i + 1).all()
 
 
+def test_custom_anomaly_detector_transform():
+    """Test collective anomaly detector's transform method (dense output)."""
+    detector = MoscoreAnomaly(
+        score=(mean_anomaly_score, init_mean_score),
+        min_anomaly_length=2,
+        max_anomaly_length=8,
+        left_bandwidth=4,
+    )
+    labels = detector.fit_transform(anomaly_data)
+    if isinstance(labels, pd.DataFrame):
+        labels = labels.iloc[:, 0]
+
+    true_collective_anomalies = pd.IntervalIndex.from_tuples(
+        true_anomalies, closed="both"
+    )
+    true_anomaly_labels = CollectiveAnomalyDetector.sparse_to_dense(
+        true_collective_anomalies, anomaly_data.index
+    )
+    labels.equals(true_anomaly_labels)
+
+    # Similar test that does not depend on sparse_to_dense, just to be sure.
+    assert labels.nunique() == len(true_anomalies) + 1
+    for i, (start, end) in enumerate(true_anomalies):
+        assert (labels.iloc[start : end + 1] == i + 1).all()
+
+
 @pytest.mark.parametrize("Estimator", ANOMALY_DETECTORS)
-def test_anomaly_detector_sparse_to_dense(Estimator):
+def test_anomaly_detector_sparse_to_dense(Estimator: CollectiveAnomalyDetector):
     """Test that predict + sparse_to_dense == transform."""
     detector = Estimator.create_test_instance()
     anomalies = detector.fit_predict(anomaly_data)
@@ -61,7 +89,7 @@ def test_anomaly_detector_sparse_to_dense(Estimator):
 
 
 @pytest.mark.parametrize("Estimator", ANOMALY_DETECTORS)
-def test_anomaly_detector_dense_to_sparse(Estimator):
+def test_anomaly_detector_dense_to_sparse(Estimator: CollectiveAnomalyDetector):
     """Test that transform + dense_to_sparse == predict."""
     detector = Estimator.create_test_instance()
     labels = detector.fit_transform(anomaly_data)

--- a/skchange/change_detectors/moscore.py
+++ b/skchange/change_detectors/moscore.py
@@ -7,11 +7,11 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.scores.score_factory import score_factory
 from skchange.utils.numba.general import where
+from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_in_interval, check_larger_than
 

--- a/skchange/change_detectors/moscore.py
+++ b/skchange/change_detectors/moscore.py
@@ -10,8 +10,8 @@ import pandas as pd
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.scores.score_factory import score_factory
+from skchange.utils.numba import njit
 from skchange.utils.numba.general import where
-from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_in_interval, check_larger_than
 

--- a/skchange/change_detectors/moscore.py
+++ b/skchange/change_detectors/moscore.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.scores.score_factory import score_factory

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.costs.cost_factory import cost_factory

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -8,10 +8,10 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.costs.cost_factory import cost_factory
+from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_larger_than
 

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.costs.cost_factory import cost_factory
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_larger_than
 

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.scores.score_factory import score_factory
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_in_interval, check_larger_than
 

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -7,10 +7,10 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.scores.score_factory import score_factory
+from skchange.utils.numba.njit import njit
 from skchange.utils.validation.data import check_data
 from skchange.utils.validation.parameters import check_in_interval, check_larger_than
 

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.change_detectors.base import ChangeDetector
 from skchange.scores.score_factory import score_factory

--- a/skchange/change_detectors/tests/test_pelt.py
+++ b/skchange/change_detectors/tests/test_pelt.py
@@ -4,7 +4,6 @@ from typing import Callable
 
 import numpy as np
 import pytest
-from numba import njit
 
 from skchange.change_detectors.pelt import (
     get_changepoints,
@@ -12,6 +11,7 @@ from skchange.change_detectors.pelt import (
 )
 from skchange.costs.cost_factory import cost_factory
 from skchange.datasets.generate import generate_alternating_data
+from skchange.utils.numba import njit
 
 n_segments = 2
 seg_len = 50

--- a/skchange/costs/cost_factory.py
+++ b/skchange/costs/cost_factory.py
@@ -18,8 +18,6 @@ __author__ = ["Tveten"]
 
 from typing import Callable, Union
 
-from numba.extending import is_jitted
-
 from skchange.costs.mean_cost import init_mean_cost, mean_cost
 
 VALID_COSTS = ["mean"]
@@ -65,7 +63,7 @@ def cost_factory(cost: Union[str, tuple[Callable, Callable]]):
     """
     if cost == "mean":
         return mean_cost, init_mean_cost
-    elif len(cost) == 2 and all([is_jitted(s) for s in cost]):
+    elif len(cost) == 2:
         return cost[0], cost[1]
     else:
         message = (

--- a/skchange/costs/mean_cost.py
+++ b/skchange/costs/mean_cost.py
@@ -4,8 +4,8 @@ __author__ = ["Tveten"]
 
 import numpy as np
 
+from skchange.utils.numba import njit
 from skchange.utils.numba.general import col_repeat
-from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/costs/mean_cost.py
+++ b/skchange/costs/mean_cost.py
@@ -3,7 +3,7 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.general import col_repeat
 from skchange.utils.numba.stats import col_cumsum

--- a/skchange/costs/mean_cost.py
+++ b/skchange/costs/mean_cost.py
@@ -3,9 +3,9 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.general import col_repeat
+from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/costs/mean_cov_cost.py
+++ b/skchange/costs/mean_cov_cost.py
@@ -3,9 +3,9 @@
 __author__ = ["johannvk"]
 
 import numpy as np
-from numba import njit
 
 from skchange.scores.mean_cov_score import _mean_cov_log_det_term
+from skchange.utils.numba import njit
 
 
 @njit(cache=True)

--- a/skchange/costs/mean_saving.py
+++ b/skchange/costs/mean_saving.py
@@ -4,8 +4,8 @@ __author__ = ["Tveten"]
 
 import numpy as np
 
+from skchange.utils.numba import njit
 from skchange.utils.numba.general import col_repeat
-from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/costs/mean_saving.py
+++ b/skchange/costs/mean_saving.py
@@ -3,7 +3,7 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.general import col_repeat
 from skchange.utils.numba.stats import col_cumsum

--- a/skchange/costs/mean_saving.py
+++ b/skchange/costs/mean_saving.py
@@ -3,9 +3,9 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.general import col_repeat
+from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/costs/saving_factory.py
+++ b/skchange/costs/saving_factory.py
@@ -20,8 +20,6 @@ __author__ = ["Tveten"]
 
 from typing import Callable, Union
 
-from numba.extending import is_jitted
-
 from skchange.costs.mean_saving import init_mean_saving, mean_saving
 
 VALID_SAVINGS = ["mean"]
@@ -67,7 +65,7 @@ def saving_factory(saving: Union[str, tuple[Callable, Callable]]):
     """
     if saving == "mean":
         return mean_saving, init_mean_saving
-    elif len(saving) == 2 and all([is_jitted(s) for s in saving]):
+    elif len(saving) == 2:
         return saving[0], saving[1]
     else:
         message = (

--- a/skchange/costs/tests/test_costs.py
+++ b/skchange/costs/tests/test_costs.py
@@ -21,14 +21,12 @@ def test_costs(cost):
 
 def test_custom_cost():
     """Test custom cost."""
-    with pytest.raises(ValueError):
-        # Need to be jitted to work.
-        # Cannot test jitted function because numba is turned off in CI testing.
+    # No longer need to be jitted to work.
 
-        def init_cost_f(X: np.ndarray) -> np.ndarray:
-            return X
+    def init_cost_f(X: np.ndarray) -> np.ndarray:
+        return X
 
-        def cost_f(params: np.ndarray, start: int, end: int, split: int) -> float:
-            return 10.0
+    def cost_f(params: np.ndarray, start: int, end: int, split: int) -> float:
+        return 10.0
 
-        cost_factory((cost_f, init_cost_f))
+    assert (cost_f, init_cost_f) == cost_factory((cost_f, init_cost_f))

--- a/skchange/costs/tests/test_costs.py
+++ b/skchange/costs/tests/test_costs.py
@@ -32,3 +32,9 @@ def test_custom_cost():
     assert init_cost_f(np.zeros(1)) == np.zeros(1)
     assert cost_f(np.zeros(1), 0, 1, 0) == 10.0
     assert (cost_f, init_cost_f) == cost_factory((cost_f, init_cost_f))
+
+
+def test_cost_factory_raises_on_invalid_cost():
+    """Test that cost_factory raises an error on invalid cost."""
+    with pytest.raises(ValueError):
+        cost_factory("invalid_cost")

--- a/skchange/costs/tests/test_costs.py
+++ b/skchange/costs/tests/test_costs.py
@@ -29,4 +29,8 @@ def test_custom_cost():
     def cost_f(params: np.ndarray, start: int, end: int, split: int) -> float:
         return 10.0
 
+    assert init_cost_f(np.zeros(1)) == np.zeros(1)
+    assert cost_f(np.zeros(1), 0, 1, 0) == 10.0
     assert (cost_f, init_cost_f) == cost_factory((cost_f, init_cost_f))
+
+

--- a/skchange/costs/tests/test_costs.py
+++ b/skchange/costs/tests/test_costs.py
@@ -32,5 +32,3 @@ def test_custom_cost():
     assert init_cost_f(np.zeros(1)) == np.zeros(1)
     assert cost_f(np.zeros(1), 0, 1, 0) == 10.0
     assert (cost_f, init_cost_f) == cost_factory((cost_f, init_cost_f))
-
-

--- a/skchange/costs/tests/test_savings.py
+++ b/skchange/costs/tests/test_savings.py
@@ -21,13 +21,12 @@ def test_savings(savings):
 
 def test_custom_savings():
     """Test custom savings."""
-    # No longer need to be jitted to work.
-    # Cannot test jitted function because numba is turned off in CI testing.
-
     def init_savings_f(X: np.ndarray) -> np.ndarray:
         return X
 
     def savings_f(params: np.ndarray, start: int, end: int, split: int) -> float:
         return 10.0
 
+    assert init_savings_f(np.zeros(1)) == np.zeros(1)
+    assert savings_f(np.zeros(1), 0, 1, 0) == 10.0
     assert (savings_f, init_savings_f) == saving_factory((savings_f, init_savings_f))

--- a/skchange/costs/tests/test_savings.py
+++ b/skchange/costs/tests/test_savings.py
@@ -21,14 +21,13 @@ def test_savings(savings):
 
 def test_custom_savings():
     """Test custom savings."""
-    with pytest.raises(ValueError):
-        # Need to be jitted to work.
-        # Cannot test jitted function because numba is turned off in CI testing.
+    # No longer need to be jitted to work.
+    # Cannot test jitted function because numba is turned off in CI testing.
 
-        def init_savings_f(X: np.ndarray) -> np.ndarray:
-            return X
+    def init_savings_f(X: np.ndarray) -> np.ndarray:
+        return X
 
-        def savings_f(params: np.ndarray, start: int, end: int, split: int) -> float:
-            return 10.0
+    def savings_f(params: np.ndarray, start: int, end: int, split: int) -> float:
+        return 10.0
 
-        saving_factory((savings_f, init_savings_f))
+    assert (savings_f, init_savings_f) == saving_factory((savings_f, init_savings_f))

--- a/skchange/costs/tests/test_savings.py
+++ b/skchange/costs/tests/test_savings.py
@@ -31,3 +31,9 @@ def test_custom_savings():
     assert init_savings_f(np.zeros(1)) == np.zeros(1)
     assert savings_f(np.zeros(1), 0, 1, 0) == 10.0
     assert (savings_f, init_savings_f) == saving_factory((savings_f, init_savings_f))
+
+
+def test_savings_factory_raises_on_invalid_savings():
+    """Test that savings_factory raises an error on invalid savings."""
+    with pytest.raises(ValueError):
+        saving_factory("invalid_savings")

--- a/skchange/costs/tests/test_savings.py
+++ b/skchange/costs/tests/test_savings.py
@@ -21,6 +21,7 @@ def test_savings(savings):
 
 def test_custom_savings():
     """Test custom savings."""
+
     def init_savings_f(X: np.ndarray) -> np.ndarray:
         return X
 

--- a/skchange/scores/mean_cov_score.py
+++ b/skchange/scores/mean_cov_score.py
@@ -4,8 +4,7 @@ __author__ = ["johannvk"]
 
 import numpy as np
 
-# from skchange.utils.numba.njit import njit
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.numba.stats import log_det_covariance
 
 

--- a/skchange/scores/mean_cov_score.py
+++ b/skchange/scores/mean_cov_score.py
@@ -3,8 +3,9 @@
 __author__ = ["johannvk"]
 
 import numpy as np
-from numba import njit
 
+# from skchange.utils.numba.njit import njit
+from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import log_det_covariance
 
 

--- a/skchange/scores/mean_score.py
+++ b/skchange/scores/mean_score.py
@@ -4,7 +4,7 @@ __author__ = ["Tveten"]
 
 import numpy as np
 
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/scores/mean_score.py
+++ b/skchange/scores/mean_score.py
@@ -3,8 +3,8 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from skchange.utils.numba.njit import njit
 
+from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/scores/mean_score.py
+++ b/skchange/scores/mean_score.py
@@ -3,7 +3,7 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.stats import col_cumsum
 

--- a/skchange/scores/mean_var_score.py
+++ b/skchange/scores/mean_var_score.py
@@ -3,9 +3,9 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.general import truncate_below
+from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/scores/mean_var_score.py
+++ b/skchange/scores/mean_var_score.py
@@ -3,7 +3,7 @@
 __author__ = ["Tveten"]
 
 import numpy as np
-from numba import njit
+from skchange.utils.numba.njit import njit
 
 from skchange.utils.numba.general import truncate_below
 from skchange.utils.numba.stats import col_cumsum

--- a/skchange/scores/mean_var_score.py
+++ b/skchange/scores/mean_var_score.py
@@ -4,8 +4,8 @@ __author__ = ["Tveten"]
 
 import numpy as np
 
+from skchange.utils.numba import njit
 from skchange.utils.numba.general import truncate_below
-from skchange.utils.numba.njit import njit
 from skchange.utils.numba.stats import col_cumsum
 
 

--- a/skchange/scores/score_factory.py
+++ b/skchange/scores/score_factory.py
@@ -18,8 +18,6 @@ __author__ = ["Tveten"]
 
 from typing import Callable, Union
 
-from numba.extending import is_jitted
-
 from skchange.scores.mean_cov_score import (
     init_mean_cov_score,
     mean_cov_score,
@@ -88,7 +86,7 @@ def score_factory(score: Union[str, tuple[Callable, Callable]] = "mean"):
         return mean_var_score, init_mean_var_score
     elif isinstance(score, str) and score == "mean_cov":
         return mean_cov_score, init_mean_cov_score
-    elif len(score) == 2 and all([is_jitted(s) for s in score]):
+    elif len(score) == 2:
         return score[0], score[1]
     else:
         message = (

--- a/skchange/scores/score_factory.py
+++ b/skchange/scores/score_factory.py
@@ -146,7 +146,7 @@ def anomaly_score_factory(score: Union[str, tuple[Callable, Callable]] = "mean")
         return mean_anomaly_score, init_mean_score
     elif isinstance(score, str) and score == "mean_var":
         return mean_var_anomaly_score, init_mean_var_score
-    elif len(score) == 2 and all([is_jitted(s) for s in score]):
+    elif len(score) == 2:
         return score[0], score[1]
     else:
         message = (

--- a/skchange/scores/tests/test_scores.py
+++ b/skchange/scores/tests/test_scores.py
@@ -27,17 +27,16 @@ def test_scores(score):
 
 def test_custom_score():
     """Test custom score."""
-    with pytest.raises(ValueError):
-        # Need to be jitted to work.
+        # No longer need to be jitted to work.
         # Cannot test jitted function because numba is turned of in CI testing.
 
-        def init_score_f(X: np.ndarray) -> np.ndarray:
-            return X
+    def init_score_f(X: np.ndarray) -> np.ndarray:
+        return X
 
-        def score_f(params: np.ndarray, start: int, end: int, split: int) -> float:
-            return 10.0
+    def score_f(params: np.ndarray, start: int, end: int, split: int) -> float:
+        return 10.0
 
-        score_factory((score_f, init_score_f))
+    assert (score_f, init_score_f) == score_factory((score_f, init_score_f))
 
 
 def test_mean_cov_score_negative_definite_error():

--- a/skchange/scores/tests/test_scores.py
+++ b/skchange/scores/tests/test_scores.py
@@ -27,8 +27,8 @@ def test_scores(score):
 
 def test_custom_score():
     """Test custom score."""
-        # No longer need to be jitted to work.
-        # Cannot test jitted function because numba is turned of in CI testing.
+    # No longer need to be jitted to work.
+    # Cannot test jitted function because numba is turned of in CI testing.
 
     def init_score_f(X: np.ndarray) -> np.ndarray:
         return X

--- a/skchange/scores/tests/test_scores.py
+++ b/skchange/scores/tests/test_scores.py
@@ -36,6 +36,8 @@ def test_custom_score():
     def score_f(params: np.ndarray, start: int, end: int, split: int) -> float:
         return 10.0
 
+    assert init_score_f(np.zeros(1)) == np.zeros(1)
+    assert score_f(np.zeros(1), 0, 1, 0) == 10.0
     assert (score_f, init_score_f) == score_factory((score_f, init_score_f))
 
 

--- a/skchange/scores/tests/test_scores.py
+++ b/skchange/scores/tests/test_scores.py
@@ -4,7 +4,11 @@ import numpy as np
 import pytest
 
 from skchange.datasets.generate import generate_alternating_data
-from skchange.scores.score_factory import VALID_CHANGE_SCORES, score_factory
+from skchange.scores.score_factory import (
+    VALID_CHANGE_SCORES,
+    anomaly_score_factory,
+    score_factory,
+)
 
 
 @pytest.mark.parametrize("score", VALID_CHANGE_SCORES)
@@ -55,3 +59,15 @@ def test_mean_cov_score_negative_definite_error():
         score_f(
             params, starts=np.array([0]), ends=np.array([49]), splits=np.array([25])
         )
+
+
+def test_score_factory_unknown_score_raises():
+    """Test that unknown score raises an error."""
+    with pytest.raises(ValueError):
+        score_factory("unknown_score")
+
+
+def test_anomaly_score_factory_unknown_score_raises():
+    """Test that unknown score raises an error."""
+    with pytest.raises(ValueError):
+        anomaly_score_factory("unknown_score")

--- a/skchange/tests/test_all_detectors.py
+++ b/skchange/tests/test_all_detectors.py
@@ -20,7 +20,7 @@ def test_sktime_compatible_estimators(obj, test_name):
 
 
 @pytest.mark.parametrize("Detector", ALL_DETECTORS)
-def test_detector_fit(Detector):
+def test_detector_fit(Detector: BaseDetector):
     """Test fit method output."""
     detector = Detector.create_test_instance()
     x = make_annotation_problem(n_timepoints=50, estimator_type="None")
@@ -32,7 +32,7 @@ def test_detector_fit(Detector):
 
 
 @pytest.mark.parametrize("Detector", ALL_DETECTORS)
-def test_detector_predict(Detector):
+def test_detector_predict(Detector: BaseDetector):
     """Test predict method output."""
     detector = Detector.create_test_instance()
     x = generate_anomalous_data(means=10, random_state=60)
@@ -41,7 +41,7 @@ def test_detector_predict(Detector):
 
 
 @pytest.mark.parametrize("Detector", ALL_DETECTORS)
-def test_detector_transform(Detector):
+def test_detector_transform(Detector: BaseDetector):
     """Test transform method output."""
     detector = Detector.create_test_instance()
     x = generate_anomalous_data(means=10, random_state=61)
@@ -51,7 +51,7 @@ def test_detector_transform(Detector):
 
 
 @pytest.mark.parametrize("Detector", ALL_DETECTORS)
-def test_detector_score_transform(Detector):
+def test_detector_score_transform(Detector: BaseDetector):
     """Test score_transform method output."""
     detector = Detector.create_test_instance()
     x = generate_anomalous_data(means=10, random_state=62)
@@ -63,7 +63,7 @@ def test_detector_score_transform(Detector):
 
 
 @pytest.mark.parametrize("Detector", ALL_DETECTORS)
-def test_detector_update(Detector):
+def test_detector_update(Detector: BaseDetector):
     """Test update method output."""
     detector = Detector.create_test_instance()
     x = make_annotation_problem(n_timepoints=30, estimator_type="None")

--- a/skchange/utils/numba/__init__.py
+++ b/skchange/utils/numba/__init__.py
@@ -1,1 +1,2 @@
 """Numba utility functions."""
+from .soft_import import jit, njit, prange

--- a/skchange/utils/numba/__init__.py
+++ b/skchange/utils/numba/__init__.py
@@ -1,2 +1,3 @@
 """Numba utility functions."""
+
 from .soft_import import jit, njit, prange

--- a/skchange/utils/numba/general.py
+++ b/skchange/utils/numba/general.py
@@ -1,4 +1,4 @@
-"""Numba-optimized functions for various common data manipulation tasks.""" ""
+"""Numba-optimized functions for various common data manipulation tasks."""
 
 import numpy as np
 

--- a/skchange/utils/numba/general.py
+++ b/skchange/utils/numba/general.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from skchange.utils.numba.njit import njit, prange
+from skchange.utils.numba import njit, prange
 
 
 @njit(cache=True)

--- a/skchange/utils/numba/general.py
+++ b/skchange/utils/numba/general.py
@@ -1,7 +1,8 @@
 """Numba-optimized functions for various common data manipulation tasks.""" ""
 
 import numpy as np
-from numba import njit, prange
+
+from skchange.utils.numba.njit import njit, prange
 
 
 @njit(cache=True)

--- a/skchange/utils/numba/njit.py
+++ b/skchange/utils/numba/njit.py
@@ -9,6 +9,22 @@ from os import environ
 from sktime.utils.dependencies import _check_soft_dependencies
 
 
+def define_prange(_):
+    """Dispatch prange based on environment variables."""
+    if _check_soft_dependencies("numba", severity="none"):
+        from numba import prange as numba_prange
+
+        return numba_prange
+    else:
+        return range
+
+
+@define_prange
+def prange(*args, **kwargs):
+    """Dispatch prange based on numba dependency."""
+    pass
+
+
 def read_boolean_env_var(name, default_value):
     """Read a boolean environment variable."""
     truthy_strings = ["", "1", "true", "True", "TRUE"]
@@ -28,66 +44,108 @@ def read_boolean_env_var(name, default_value):
         )
 
 
-def define_jit_and_njit():
-    # exports numba.njit if numba is present, otherwise an identity njit
-    if _check_soft_dependencies("numba", severity="ignore"):
-        from numba import jit as numba_jit, njit as numba_njit  # noqa E402
+def configure_jit(jit_default_kwargs=None):
+    """Decorate jit with default kwargs from environment variables."""
+    if jit_default_kwargs is None:
+        jit_default_kwargs = {}
 
-        # Read possible 'NUMBA_CACHE' environment variable:
-        numba_cache = read_boolean_env_var("NUMBA_CACHE", default_value=True)
+    def decorator(_):
+        if _check_soft_dependencies("numba", severity="none"):
+            from numba import jit as numba_jit
 
-        # Read possible 'NUMBA_PARALLEL' environment variable:
-        numba_parallel = read_boolean_env_var("NUMBA_PARALLEL", default_value=False)
+            @wraps(numba_jit)
+            def jit(maybe_func=None, **kwargs):
+                """Dispatch jit decorator based on environment variables."""
+                # This syntax overwrites the default kwargs
+                # with the provided kwargs if they overlap.
+                kwargs = {**jit_default_kwargs, **kwargs}
+                return numba_jit(maybe_func, **kwargs)
 
-        # Read possible 'NUMBA_FASTMATH' environment variable:
-        numba_fastmath = read_boolean_env_var("NUMBA_FASTMATH", default_value=False)
+        else:
 
-        def jit(**kwargs):
-            """Dispatch jit decorator based on environment variables."""
-            if "cache" not in kwargs:
-                kwargs["cache"] = numba_cache
+            def jit(maybe_func=None, **kwargs):
+                """Identity decorator for replacing jit by passthrough."""
+                if callable(maybe_func):
+                    # Called with the 'direct' syntax:
+                    # @jit
+                    # def func(*args, **kwargs):
+                    #     ...
+                    return maybe_func
+                else:
+                    # Called with arguments to the decorator:
+                    # @jit(cache=True)
+                    # def func(*args, **kwargs):
+                    #     ...
+                    def decorator(func):
+                        return func
 
-            if "fastmath" not in kwargs:
-                kwargs["fastmath"] = numba_fastmath
+                    return decorator
 
-            if "parallel" not in kwargs:
-                kwargs["parallel"] = numba_parallel
+        return jit
 
-            return numba_jit(**kwargs)
-
-        # Figure out how to use "wraps" correctly here:
-        def njit(**kwargs):
-            """Dispatch njit decorator based on environment variables."""
-            if "cache" not in kwargs:
-                kwargs["cache"] = numba_cache
-
-            if "fastmath" not in kwargs:
-                kwargs["fastmath"] = numba_fastmath
-
-            if "parallel" not in kwargs:
-                kwargs["parallel"] = numba_parallel
-
-            return numba_njit(**kwargs)
-
-    else:
-
-        def jit(*args, **kwargs):
-            """Identity decorator for replacing njit by passthrough."""
-
-            def decorator(func):
-                return func
-
-            return decorator
-
-        def njit(*args, **kwargs):
-            """Identity decorator for replacing njit by passthrough."""
-
-            def decorator(func):
-                return func
-
-            return decorator
-
-    return jit, njit
+    return decorator
 
 
-jit, njit = define_jit_and_njit()
+def configure_njit(njit_default_kwargs=None):
+    """Configure njit with default kwargs from environment variables."""
+    if njit_default_kwargs is None:
+        njit_default_kwargs = {}
+
+    def decorator(_):
+        if _check_soft_dependencies("numba", severity="none"):
+            from numba import njit as numba_njit
+
+            @wraps(numba_njit)
+            def njit(maybe_func=None, **kwargs):
+                """Dispatch njit decorator based on environment variables."""
+                kwargs = {**njit_default_kwargs, **kwargs}
+                print(kwargs)
+                return numba_njit(maybe_func, **kwargs)
+
+        else:
+
+            def njit(maybe_func=None, **kwargs):
+                """Identity decorator for replacing njit by passthrough."""
+                if callable(maybe_func):
+                    # Called with the 'direct' syntax:
+                    # @njit
+                    # def func(*args, **kwargs):
+                    #     ...
+                    return maybe_func
+                else:
+                    # Called with arguments to the decorator:
+                    # @jit(cache=True)
+                    # def func(*args, **kwargs):
+                    #     ...
+                    def decorator(func):
+                        return func
+
+                    return decorator
+
+        return njit
+
+    return decorator
+
+
+@configure_jit(
+    jit_default_kwargs={
+        "cache": read_boolean_env_var("NUMBA_CACHE", default_value=False),
+        "fastmath": read_boolean_env_var("NUMBA_FASTMATH", default_value=False),
+        "parallel": read_boolean_env_var("NUMBA_PARALLEL", default_value=False),
+    },
+)
+def jit():
+    """Dispatch jit decorator based on environment variables."""
+    pass
+
+
+@configure_njit(
+    njit_default_kwargs={
+        "cache": read_boolean_env_var("NUMBA_CACHE", default_value=True),
+        "fastmath": read_boolean_env_var("NUMBA_FASTMATH", default_value=False),
+        "parallel": read_boolean_env_var("NUMBA_PARALLEL", default_value=False),
+    }
+)
+def njit():
+    """Dispatch njit decorator based on environment variables."""
+    pass

--- a/skchange/utils/numba/njit.py
+++ b/skchange/utils/numba/njit.py
@@ -1,0 +1,27 @@
+"""Dispatch njit decorator used to isolate numba.
+
+Copied from sktime.utils.numba.njit
+"""
+
+from sktime.utils.dependencies import _check_soft_dependencies
+
+# exports numba.njit if numba is present, otherwise an identity njit
+if _check_soft_dependencies("numba", severity="ignore"):
+    from numba import jit, njit  # noqa E402
+else:
+
+    def jit(*args, **kwargs):
+        """Identity decorator for replacing njit by passthrough."""
+
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def njit(*args, **kwargs):
+        """Identity decorator for replacing njit by passthrough."""
+
+        def decorator(func):
+            return func
+
+        return decorator

--- a/skchange/utils/numba/njit.py
+++ b/skchange/utils/numba/njit.py
@@ -3,25 +3,91 @@
 Copied from sktime.utils.numba.njit
 """
 
+from functools import wraps
+from os import environ
+
 from sktime.utils.dependencies import _check_soft_dependencies
 
-# exports numba.njit if numba is present, otherwise an identity njit
-if _check_soft_dependencies("numba", severity="ignore"):
-    from numba import jit, njit  # noqa E402
-else:
 
-    def jit(*args, **kwargs):
-        """Identity decorator for replacing njit by passthrough."""
+def read_boolean_env_var(name, default_value):
+    """Read a boolean environment variable."""
+    truthy_strings = ["", "1", "true", "True", "TRUE"]
+    falsy_strings = ["0", "false", "False", "FALSE"]
 
-        def decorator(func):
-            return func
+    env_value = environ.get(name)
+    if env_value is None:
+        return default_value
 
-        return decorator
+    if env_value in truthy_strings:
+        return True
+    elif env_value in falsy_strings:
+        return False
+    else:
+        raise ValueError(
+            f"Invalid value for boolean environment variable '{name}': {env_value}"
+        )
 
-    def njit(*args, **kwargs):
-        """Identity decorator for replacing njit by passthrough."""
 
-        def decorator(func):
-            return func
+def define_jit_and_njit():
+    # exports numba.njit if numba is present, otherwise an identity njit
+    if _check_soft_dependencies("numba", severity="ignore"):
+        from numba import jit as numba_jit, njit as numba_njit  # noqa E402
 
-        return decorator
+        # Read possible 'NUMBA_CACHE' environment variable:
+        numba_cache = read_boolean_env_var("NUMBA_CACHE", default_value=True)
+
+        # Read possible 'NUMBA_PARALLEL' environment variable:
+        numba_parallel = read_boolean_env_var("NUMBA_PARALLEL", default_value=False)
+
+        # Read possible 'NUMBA_FASTMATH' environment variable:
+        numba_fastmath = read_boolean_env_var("NUMBA_FASTMATH", default_value=False)
+
+        def jit(**kwargs):
+            """Dispatch jit decorator based on environment variables."""
+            if "cache" not in kwargs:
+                kwargs["cache"] = numba_cache
+
+            if "fastmath" not in kwargs:
+                kwargs["fastmath"] = numba_fastmath
+
+            if "parallel" not in kwargs:
+                kwargs["parallel"] = numba_parallel
+
+            return numba_jit(**kwargs)
+
+        # Figure out how to use "wraps" correctly here:
+        def njit(**kwargs):
+            """Dispatch njit decorator based on environment variables."""
+            if "cache" not in kwargs:
+                kwargs["cache"] = numba_cache
+
+            if "fastmath" not in kwargs:
+                kwargs["fastmath"] = numba_fastmath
+
+            if "parallel" not in kwargs:
+                kwargs["parallel"] = numba_parallel
+
+            return numba_njit(**kwargs)
+
+    else:
+
+        def jit(*args, **kwargs):
+            """Identity decorator for replacing njit by passthrough."""
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def njit(*args, **kwargs):
+            """Identity decorator for replacing njit by passthrough."""
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    return jit, njit
+
+
+jit, njit = define_jit_and_njit()

--- a/skchange/utils/numba/soft_import.py
+++ b/skchange/utils/numba/soft_import.py
@@ -56,7 +56,7 @@ def define_prange(_):
 @define_prange
 def prange(*args, **kwargs):
     """Dispatch prange based on numba dependency."""
-    ...
+    ...  # pragma: no cover
 
 
 def read_boolean_env_var(name, default_value):
@@ -168,7 +168,7 @@ def configure_njit(njit_default_kwargs):
 )
 def jit():
     """Dispatch jit decorator based on environment variables."""
-    ...
+    ...  # pragma: no cover
 
 
 @configure_njit(
@@ -180,4 +180,4 @@ def jit():
 )
 def njit():
     """Dispatch njit decorator based on environment variables."""
-    ...
+    ...  # pragma: no cover

--- a/skchange/utils/numba/soft_import.py
+++ b/skchange/utils/numba/soft_import.py
@@ -33,6 +33,9 @@ variables in the `.env` file in the root of the project directory.
 Additionally, we provide a `prange` function that dispatches to `numba.prange`.
 If `numba` is not installed, it dispatches to the regular Python `range`.
 
+For additional numba configurations, including how to disable numba, see
+`https://numba.readthedocs.io/en/stable/reference/envvars.html`_.
+
 The functionality to check for whether or not `numba` is installed
 is copied from `sktime.utils.numba.njit`.
 """

--- a/skchange/utils/numba/soft_import.py
+++ b/skchange/utils/numba/soft_import.py
@@ -80,6 +80,7 @@ def read_boolean_env_var(name, default_value):
 
 def configure_jit(jit_default_kwargs):
     """Decorate jit with default kwargs from environment variables."""
+
     def decorator(_):
         if _check_soft_dependencies("numba", severity="none"):
             from numba import jit as numba_jit
@@ -119,6 +120,7 @@ def configure_jit(jit_default_kwargs):
 
 def configure_njit(njit_default_kwargs):
     """Configure njit with default kwargs from environment variables."""
+
     def decorator(_):
         if _check_soft_dependencies("numba", severity="none"):
             from numba import njit as numba_njit

--- a/skchange/utils/numba/soft_import.py
+++ b/skchange/utils/numba/soft_import.py
@@ -56,7 +56,7 @@ def define_prange(_):
 @define_prange
 def prange(*args, **kwargs):
     """Dispatch prange based on numba dependency."""
-    pass
+    ...
 
 
 def read_boolean_env_var(name, default_value):
@@ -166,7 +166,7 @@ def configure_njit(njit_default_kwargs):
 )
 def jit():
     """Dispatch jit decorator based on environment variables."""
-    pass
+    ...
 
 
 @configure_njit(
@@ -178,4 +178,4 @@ def jit():
 )
 def njit():
     """Dispatch njit decorator based on environment variables."""
-    pass
+    ...

--- a/skchange/utils/numba/soft_import.py
+++ b/skchange/utils/numba/soft_import.py
@@ -78,11 +78,8 @@ def read_boolean_env_var(name, default_value):
         )
 
 
-def configure_jit(jit_default_kwargs=None):
+def configure_jit(jit_default_kwargs):
     """Decorate jit with default kwargs from environment variables."""
-    if jit_default_kwargs is None:
-        jit_default_kwargs = {}
-
     def decorator(_):
         if _check_soft_dependencies("numba", severity="none"):
             from numba import jit as numba_jit
@@ -120,11 +117,8 @@ def configure_jit(jit_default_kwargs=None):
     return decorator
 
 
-def configure_njit(njit_default_kwargs=None):
+def configure_njit(njit_default_kwargs):
     """Configure njit with default kwargs from environment variables."""
-    if njit_default_kwargs is None:
-        njit_default_kwargs = {}
-
     def decorator(_):
         if _check_soft_dependencies("numba", severity="none"):
             from numba import njit as numba_njit

--- a/skchange/utils/numba/stats.py
+++ b/skchange/utils/numba/stats.py
@@ -1,7 +1,8 @@
 """Numba-optimized functions for calculating various statistics."""
 
 import numpy as np
-from numba import njit
+
+from skchange.utils.numba.njit import njit
 
 
 @njit(cache=True)

--- a/skchange/utils/numba/stats.py
+++ b/skchange/utils/numba/stats.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from skchange.utils.numba.njit import njit
+from skchange.utils.numba import njit
 
 
 @njit(cache=True)

--- a/skchange/utils/numba/tests/test_soft_imports.py
+++ b/skchange/utils/numba/tests/test_soft_imports.py
@@ -81,6 +81,22 @@ def test_jit_function():
         assert multiply(2, 3) == 6
 
 
+def test_jit_function_with_args():
+    @jit(cache=True)
+    def multiply(a, b):
+        return a * b
+
+    assert multiply(2, 3) == 6
+
+
+def test_njit_function_with_args():
+    @njit(cache=True)
+    def add(a, b):
+        return a + b
+
+    assert add(1, 2) == 3
+
+
 def test_prange_function():
     with temp_env_and_modules(
         remove_module_prefix="skchange", env_vars={"NUMBA_DISABLE_JIT": "1"}

--- a/skchange/utils/numba/tests/test_soft_imports.py
+++ b/skchange/utils/numba/tests/test_soft_imports.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 
 import pytest
 
+from skchange.utils.numba import jit, njit, prange
+
 
 def remove_modules_with_prefix(prefix):
     to_remove = [mod for mod in sys.modules if mod.startswith(prefix)]
@@ -53,3 +55,42 @@ def test_setting_falsy_env_variable_does_not_raise():
         import skchange.utils.numba  # noqa: F401, I001
 
     assert True
+
+
+def test_njit_function():
+    with temp_env_and_modules(
+        remove_module_prefix="skchange", env_vars={"NUMBA_DISABLE_JIT": "1"}
+    ):
+
+        @njit
+        def add(a, b):
+            return a + b
+
+        assert add(1, 2) == 3
+
+
+def test_jit_function():
+    with temp_env_and_modules(
+        remove_module_prefix="skchange", env_vars={"NUMBA_DISABLE_JIT": "1"}
+    ):
+
+        @jit
+        def multiply(a, b):
+            return a * b
+
+        assert multiply(2, 3) == 6
+
+
+def test_prange_function():
+    with temp_env_and_modules(
+        remove_module_prefix="skchange", env_vars={"NUMBA_DISABLE_JIT": "1"}
+    ):
+
+        @njit(parallel=True)
+        def sum_prange(n):
+            total = 0
+            for i in prange(n):
+                total += i
+            return total
+
+        assert sum_prange(10) == sum(range(10))

--- a/skchange/utils/numba/tests/test_soft_imports.py
+++ b/skchange/utils/numba/tests/test_soft_imports.py
@@ -1,0 +1,55 @@
+import os
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+
+def remove_modules_with_prefix(prefix):
+    to_remove = [mod for mod in sys.modules if mod.startswith(prefix)]
+    for mod in to_remove:
+        del sys.modules[mod]
+
+
+@contextmanager
+def temp_env_and_modules(remove_module_prefix: str, env_vars: dict):
+    original_modules = sys.modules.copy()
+    original_environ = os.environ.copy()
+    remove_modules_with_prefix(remove_module_prefix)
+    os.environ.clear()
+    os.environ.update(env_vars)
+    try:
+        yield
+    finally:
+        sys.modules.clear()
+        sys.modules.update(original_modules)
+        os.environ.clear()
+        os.environ.update(original_environ)
+
+
+def test_setting_wrong_env_variable_raises():
+    with (
+        temp_env_and_modules(
+            remove_module_prefix="skchange", env_vars={"NUMBA_CACHE": "invalid_value"}
+        ),
+        pytest.raises(ValueError),
+    ):
+        import skchange.utils.numba  # noqa: F401, I001
+
+
+def test_setting_truthy_env_variable_does_not_raise():
+    with temp_env_and_modules(
+        remove_module_prefix="skchange", env_vars={"NUMBA_FASTMATH": "1"}
+    ):
+        import skchange.utils.numba  # noqa: F401, I001
+
+    assert True
+
+
+def test_setting_falsy_env_variable_does_not_raise():
+    with temp_env_and_modules(
+        remove_module_prefix="skchange", env_vars={"NUMBA_FASTMATH": "0"}
+    ):
+        import skchange.utils.numba  # noqa: F401, I001
+
+    assert True


### PR DESCRIPTION
This PR adds numba as a weak / optional dependency of `skchange`, instead of the hard dependency it is now.
To achieve this, we use  the `sktime` function `_check_soft_dependencies`, and return a passthrough version of the `@jit` and `@njit` decorators if `numba` is not installed.

Additionally, this PR enables the configuring of some `numba` default `@njit` parameters through the setting of environment variables.
Currently the supported parameters are `cache`, `parallel`, and `fastmath`, set by the corresponding environment variables `NUMBA_CACHE`, `NUMBA_PARALLEL`, and `NUMBA_FASTMATH`. 
The current implementation only sets the defaults, so if a user of the `numba` decorator specifies e.g. `fastmath=False`, their choice will not be overridden.