### PR TITLE
Homogenize `skchange` with `sktime`: Predict and transform DataFrame output

### DIFF
--- a/docs/source/api_reference/anomaly_detectors.rst
+++ b/docs/source/api_reference/anomaly_detectors.rst
@@ -13,7 +13,6 @@ Base
 
     CollectiveAnomalyDetector
     SubsetCollectiveAnomalyDetector
-    PointAnomalyDetector
 
 Collective anomaly detectors
 ----------------------------

--- a/skchange/anomaly_detectors/__init__.py
+++ b/skchange/anomaly_detectors/__init__.py
@@ -3,7 +3,6 @@
 from skchange.anomaly_detectors.anomalisers import StatThresholdAnomaliser
 from skchange.anomaly_detectors.base import (
     CollectiveAnomalyDetector,
-    PointAnomalyDetector,
     SubsetCollectiveAnomalyDetector,
 )
 from skchange.anomaly_detectors.capa import CAPA
@@ -12,7 +11,6 @@ from skchange.anomaly_detectors.mvcapa import MVCAPA
 
 BASE_ANOMALY_DETECTORS = [
     CollectiveAnomalyDetector,
-    PointAnomalyDetector,
     SubsetCollectiveAnomalyDetector,
 ]
 COLLECTIVE_ANOMALY_DETECTORS = [

--- a/skchange/anomaly_detectors/anomalisers.py
+++ b/skchange/anomaly_detectors/anomalisers.py
@@ -80,10 +80,10 @@ class StatThresholdAnomaliser(CollectiveAnomalyDetector):
             exact format depends on annotation type
         """
         # This is the required output format for the rest of the code to work.
-        segments = self.change_detector_.transform(X)
+        segments = self.change_detector_.transform(X)["labels"]
         df = pd.concat([X, segments], axis=1)
         anomalies = []
-        for _, segment in df.reset_index(drop=True).groupby("segment_label"):
+        for _, segment in df.reset_index(drop=True).groupby("labels"):
             segment_stat = self.stat(segment.iloc[:, 0].values)
             if (segment_stat < self.stat_lower) | (segment_stat > self.stat_upper):
                 anomalies.append((int(segment.index[0]), int(segment.index[-1] + 1)))

--- a/skchange/anomaly_detectors/base.py
+++ b/skchange/anomaly_detectors/base.py
@@ -1,7 +1,6 @@
 """Base classes for anomaly detectors.
 
     classes:
-        PointAnomalyDetector
         CollectiveAnomalyDetector
         SubsetCollectiveAnomalyDetector
 
@@ -21,67 +20,6 @@ import numpy as np
 import pandas as pd
 
 from skchange.base import BaseDetector
-
-
-class PointAnomalyDetector(BaseDetector):
-    """Base class for point anomaly detectors.
-
-    Point anomaly detectors detect individual data points that are considered anomalous.
-
-    Output format of the predict method: See the dense_to_sparse method.
-    Output format of the transform method: See the sparse_to_dense method.
-    """
-
-    @staticmethod
-    def sparse_to_dense(
-        y_sparse: pd.Series, index: pd.Index, columns: pd.Index = None
-    ) -> pd.Series:
-        """Convert the sparse output from the predict method to a dense format.
-
-        Parameters
-        ----------
-        y_sparse : pd.Series
-            The sparse output from an anomaly detector's predict method.
-        index : array-like
-            Indices that are to be annotated according to ``y_sparse``.
-        columns: array-like
-            Not used. Only for API compatibility.
-
-        Returns
-        -------
-        pd.Series where 0-entries are normal and 1-entries are anomalous.
-        """
-        y_dense = pd.Series(0, index=index, name="anomaly_label", dtype="int64")
-        y_dense.iloc[y_sparse.values] = 1
-        return y_dense
-
-    @staticmethod
-    def dense_to_sparse(y_dense: pd.Series) -> pd.Series:
-        """Convert the dense output from the transform method to a sparse format.
-
-        Parameters
-        ----------
-        y_dense : pd.Series
-            The dense output from an anomaly detector's transform method.
-            0-entries are normal and >0-entries are anomalous.
-
-        Returns
-        -------
-        pd.Series of the integer locations of the anomalous data points.
-        """
-        # The sparse format only uses integer positions, so we reset the index.
-        y_dense = y_dense.reset_index(drop=True)
-
-        anomalies = y_dense.iloc[y_dense.values > 0].index
-        return PointAnomalyDetector._format_sparse_output(anomalies)
-
-    @staticmethod
-    def _format_sparse_output(anomalies) -> pd.Series:
-        """Format the sparse output of anomaly detectors.
-
-        Can be reused by subclasses to format the output of the _predict method.
-        """
-        return pd.Series(anomalies, name="anomaly", dtype="int64")
 
 
 class CollectiveAnomalyDetector(BaseDetector):

--- a/skchange/anomaly_detectors/tests/test_anomaly_detectors.py
+++ b/skchange/anomaly_detectors/tests/test_anomaly_detectors.py
@@ -22,9 +22,7 @@ def test_collective_anomaly_detector_predict(Estimator: CollectiveAnomalyDetecto
     """Test collective anomaly detector's predict method (sparse output)."""
     detector = Estimator.create_test_instance()
     detector.fit(anomaly_free_data)
-    anomalies = detector.predict(anomaly_data)
-    if isinstance(anomalies, pd.DataFrame):
-        anomalies = anomalies.iloc[:, 0]
+    anomalies = detector.predict(anomaly_data)["ilocs"]
 
     assert len(anomalies) == len(true_anomalies)
     for i, (start, end) in enumerate(true_anomalies):
@@ -37,11 +35,11 @@ def test_collective_anomaly_detector_transform(Estimator: CollectiveAnomalyDetec
     detector = Estimator.create_test_instance()
     detector.fit(anomaly_free_data)
     labels = detector.transform(anomaly_data)
-    if isinstance(labels, pd.DataFrame):
-        labels = labels.iloc[:, 0]
+    # if isinstance(labels, pd.DataFrame):
+    #     labels = labels.iloc[:, 0]
 
-    true_collective_anomalies = pd.IntervalIndex.from_tuples(
-        true_anomalies, closed="both"
+    true_collective_anomalies = pd.DataFrame(
+        {"ilocs": pd.IntervalIndex.from_tuples(true_anomalies, closed="left")}
     )
     true_anomaly_labels = CollectiveAnomalyDetector.sparse_to_dense(
         true_collective_anomalies, anomaly_data.index
@@ -49,6 +47,7 @@ def test_collective_anomaly_detector_transform(Estimator: CollectiveAnomalyDetec
     labels.equals(true_anomaly_labels)
 
     # Similar test that does not depend on sparse_to_dense, just to be sure.
+    labels = labels.iloc[:, 0]
     assert labels.nunique() == len(true_anomalies) + 1
     for i, (start, end) in enumerate(true_anomalies):
         assert (labels.iloc[start:end] == i + 1).all()

--- a/skchange/base/base_detector.py
+++ b/skchange/base/base_detector.py
@@ -217,10 +217,19 @@ class BaseDetector(BaseEstimator):
 
         Returns
         -------
-        y : pd.Series or pd.DataFrame
-            Detections for sequence X. The returned detections will be in the dense
-            format, meaning that each element in X will be annotated according to the
-            detection results in some meaningful way depending on the detector type.
+        y : pd.DataFrame
+            If the detector does not have the capability to identify subsets of
+            variables that are affected by the detected events, out output will be a
+            `pd.DataFrame` with the same index as X and one column:
+
+            * `"labels"`: Integer labels starting from 0.
+
+            If the detector has this capability, the output will be a `pd.DataFrame`
+            with the same index as X and as many columns as there are columns in X
+            of the following format:
+
+            * `"labels_<X.columns[i]>"` for each column index i in X.columns: Integer
+            labels starting from 0.
         """
         y = self.predict(X)
         X_inner = pd.DataFrame(X)

--- a/skchange/base/base_detector.py
+++ b/skchange/base/base_detector.py
@@ -175,7 +175,7 @@ class BaseDetector(BaseEstimator):
 
         Returns
         -------
-        y : pd.Series or pd.DataFrame
+        y : pd.DataFrame
             Each element or row corresponds to a detected event. Exact format depends on
             the detector type.
         """
@@ -201,7 +201,7 @@ class BaseDetector(BaseEstimator):
 
         Returns
         -------
-        y : pd.Series or pd.DataFrame
+        y : pd.DataFrame
             Each element or row corresponds to a detected event. Exact format depends on
             the detector type.
         """

--- a/skchange/change_detectors/base.py
+++ b/skchange/change_detectors/base.py
@@ -77,8 +77,9 @@ class ChangeDetector(BaseDetector):
 
         Returns
         -------
-        pd.Series :
-            Changepoint iloc locations.
+        pd.DataFrame :
+            A `pd.DataFrame` with a range index and one column:
+            * ``"ilocs"`` - integer locations of the changepoints.
         """
         y_dense = y_dense.reset_index(drop=True)
         is_changepoint = y_dense.diff().abs() > 0
@@ -90,5 +91,16 @@ class ChangeDetector(BaseDetector):
         """Format the sparse output of changepoint detectors.
 
         Can be reused by subclasses to format the output of the `_predict` method.
+
+        Parameters
+        ----------
+        changepoints : list
+            List of changepoint locations.
+
+        Returns
+        -------
+        pd.DataFrame :
+            A `pd.DataFrame` with a range index and one column:
+            * ``"ilocs"`` - integer locations of the changepoints.
         """
         return pd.DataFrame(changepoints, columns=["ilocs"], dtype="int64")

--- a/skchange/change_detectors/base.py
+++ b/skchange/change_detectors/base.py
@@ -67,12 +67,12 @@ class ChangeDetector(BaseDetector):
         )
 
     @staticmethod
-    def dense_to_sparse(y_dense: pd.Series) -> pd.Series:
+    def dense_to_sparse(y_dense: pd.DataFrame) -> pd.Series:
         """Convert the dense output from the `transform` method to a sparse format.
 
         Parameters
         ----------
-        y_dense : pd.Series
+        y_dense : pd.DataFrame
             The dense output from a changepoint detector's `transform` method.
 
         Returns
@@ -81,8 +81,7 @@ class ChangeDetector(BaseDetector):
             A `pd.DataFrame` with a range index and one column:
             * ``"ilocs"`` - integer locations of the changepoints.
         """
-        y_dense = y_dense.reset_index(drop=True)
-        is_changepoint = y_dense.diff().abs() > 0
+        is_changepoint = y_dense["labels"].diff().abs() > 0
         changepoints = y_dense.index[is_changepoint]
         return ChangeDetector._format_sparse_output(changepoints)
 

--- a/skchange/change_detectors/base.py
+++ b/skchange/change_detectors/base.py
@@ -67,7 +67,7 @@ class ChangeDetector(BaseDetector):
         )
 
     @staticmethod
-    def dense_to_sparse(y_dense: pd.DataFrame) -> pd.Series:
+    def dense_to_sparse(y_dense: pd.DataFrame) -> pd.DataFrame:
         """Convert the dense output from the `transform` method to a sparse format.
 
         Parameters

--- a/skchange/change_detectors/base.py
+++ b/skchange/change_detectors/base.py
@@ -36,7 +36,7 @@ class ChangeDetector(BaseDetector):
 
     @staticmethod
     def sparse_to_dense(
-        y_sparse: pd.Series, index: pd.Index, columns: pd.Index = None
+        y_sparse: pd.DataFrame, index: pd.Index, columns: pd.Index = None
     ) -> pd.Series:
         """Convert the sparse output from the `predict` method to a dense format.
 
@@ -51,18 +51,19 @@ class ChangeDetector(BaseDetector):
 
         Returns
         -------
-        pd.Series with integer labels 0, ..., K for each segment between two
-            changepoints.
+        pd.DataFrame with the input data index and one column:
+        * ``"label"`` - integer labels 0, ..., K for each segment between two
+        changepoints.
         """
-        changepoints = y_sparse.to_list()
+        changepoints = y_sparse["ilocs"].to_list()
         n = len(index)
         changepoints = [0] + changepoints + [n]
         segment_labels = np.zeros(n)
         for i in range(len(changepoints) - 1):
             segment_labels[changepoints[i] : changepoints[i + 1]] = i
 
-        return pd.Series(
-            segment_labels, index=index, name="segment_label", dtype="int64"
+        return pd.DataFrame(
+            segment_labels, index=index, columns=["labels"], dtype="int64"
         )
 
     @staticmethod
@@ -85,9 +86,9 @@ class ChangeDetector(BaseDetector):
         return ChangeDetector._format_sparse_output(changepoints)
 
     @staticmethod
-    def _format_sparse_output(changepoints) -> pd.Series:
+    def _format_sparse_output(changepoints) -> pd.DataFrame:
         """Format the sparse output of changepoint detectors.
 
         Can be reused by subclasses to format the output of the `_predict` method.
         """
-        return pd.Series(changepoints, name="changepoint", dtype="int64")
+        return pd.DataFrame(changepoints, columns=["ilocs"], dtype="int64")

--- a/skchange/change_detectors/tests/test_change_detectors.py
+++ b/skchange/change_detectors/tests/test_change_detectors.py
@@ -45,7 +45,7 @@ def test_change_detector_sparse_to_dense(Estimator):
 def test_change_detector_dense_to_sparse(Estimator):
     """Test that transform + dense_to_sparse == predict."""
     detector = Estimator.create_test_instance()
-    labels = detector.fit_transform(changepoint_data)["labels"]
+    labels = detector.fit_transform(changepoint_data)
     changepoints = detector.dense_to_sparse(labels)["ilocs"]
     changepoints_predict = detector.fit_predict(changepoint_data)["ilocs"]
     assert changepoints.equals(changepoints_predict)

--- a/skchange/change_detectors/tests/test_change_detectors.py
+++ b/skchange/change_detectors/tests/test_change_detectors.py
@@ -17,7 +17,7 @@ changepoint_data = generate_alternating_data(
 def test_change_detector_predict(Estimator):
     """Test changepoint detector predict (sparse output)."""
     detector = Estimator.create_test_instance()
-    changepoints = detector.fit_predict(changepoint_data)
+    changepoints = detector.fit_predict(changepoint_data)["ilocs"]
     assert len(changepoints) == n_segments - 1 and changepoints[0] == seg_len
 
 
@@ -25,7 +25,7 @@ def test_change_detector_predict(Estimator):
 def test_change_detector_transform(Estimator: ChangeDetector):
     """Test changepoint detector transform (dense output)."""
     detector = Estimator.create_test_instance()
-    labels: pd.Series = detector.fit_transform(changepoint_data)
+    labels: pd.Series = detector.fit_transform(changepoint_data)["labels"]
 
     assert labels.nunique() == n_segments
     assert labels[seg_len - 1] == 0.0 and labels[seg_len] == 1.0
@@ -36,8 +36,8 @@ def test_change_detector_sparse_to_dense(Estimator):
     """Test that predict + sparse_to_dense == transform."""
     detector = Estimator.create_test_instance()
     changepoints = detector.fit_predict(changepoint_data)
-    labels = detector.sparse_to_dense(changepoints, changepoint_data.index)
-    labels_transform = detector.fit_transform(changepoint_data)
+    labels = detector.sparse_to_dense(changepoints, changepoint_data.index)["labels"]
+    labels_transform = detector.fit_transform(changepoint_data)["labels"]
     assert labels.equals(labels_transform)
 
 
@@ -45,7 +45,7 @@ def test_change_detector_sparse_to_dense(Estimator):
 def test_change_detector_dense_to_sparse(Estimator):
     """Test that transform + dense_to_sparse == predict."""
     detector = Estimator.create_test_instance()
-    labels = detector.fit_transform(changepoint_data)
-    changepoints = detector.dense_to_sparse(labels)
-    changepoints_predict = detector.fit_predict(changepoint_data)
+    labels = detector.fit_transform(changepoint_data)["labels"]
+    changepoints = detector.dense_to_sparse(labels)["ilocs"]
+    changepoints_predict = detector.fit_predict(changepoint_data)["ilocs"]
     assert changepoints.equals(changepoints_predict)

--- a/skchange/change_detectors/tests/test_moving_window.py
+++ b/skchange/change_detectors/tests/test_moving_window.py
@@ -20,7 +20,7 @@ def test_moving_window_changepoint(Score):
         n_segments=n_segments, mean=15, segment_length=seg_len, p=1, random_state=2
     )
     detector = MovingWindow(Score())
-    changepoints = detector.fit_predict(df)
+    changepoints = detector.fit_predict(df)["ilocs"]
     assert len(changepoints) == n_segments - 1 and changepoints[0] == seg_len
 
 

--- a/skchange/change_detectors/tests/test_seeded_binseg.py
+++ b/skchange/change_detectors/tests/test_seeded_binseg.py
@@ -70,6 +70,6 @@ def test_min_segment_length(min_segment_length):
     )
     detector = SeededBinarySegmentation.create_test_instance()
     detector.set_params(min_segment_length=min_segment_length, threshold_scale=0.0)
-    changepoints = detector.fit_predict(df)
+    changepoints = detector.fit_predict(df)["ilocs"]
     changepoints = np.concatenate([[0], changepoints, [len(df)]])
     assert np.all(np.diff(changepoints) >= min_segment_length)

--- a/skchange/tests/test_all_detectors.py
+++ b/skchange/tests/test_all_detectors.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-from sktime.utils._testing.annotation import make_annotation_problem
 from sktime.utils.estimator_checks import check_estimator, parametrize_with_checks
 
 from skchange.anomaly_detectors import ANOMALY_DETECTORS
@@ -23,7 +22,8 @@ def test_sktime_compatible_estimators(obj, test_name):
 def test_detector_fit(Detector: BaseDetector):
     """Test fit method output."""
     detector = Detector.create_test_instance()
-    x = make_annotation_problem(n_timepoints=50, estimator_type="None")
+    x = generate_anomalous_data()
+    x.index = pd.date_range(start="2020-01-01", periods=x.shape[0], freq="D")
     y = pd.Series(np.zeros(len(x)))  # For coverage testing.
     fit_detector = detector.fit(x, y)
     assert issubclass(detector.__class__, BaseDetector)
@@ -66,9 +66,10 @@ def test_detector_transform_scores(Detector: BaseDetector):
 def test_detector_update(Detector: BaseDetector):
     """Test update method output."""
     detector = Detector.create_test_instance()
-    x = make_annotation_problem(n_timepoints=30, estimator_type="None")
-    x_train = x[:20].to_frame()
-    x_next = x[20:].to_frame()
+    x = generate_anomalous_data()
+    x.index = pd.date_range(start="2020-01-01", periods=x.shape[0], freq="D")
+    x_train = x.iloc[:20]
+    x_next = x[20:]
     detector.fit(x_train)
     detector.update_predict(x_next)
     assert issubclass(detector.__class__, BaseDetector)
@@ -77,7 +78,8 @@ def test_detector_update(Detector: BaseDetector):
 
 def test_detector_not_implemented_methods():
     detector = BaseDetector()
-    x = make_annotation_problem(n_timepoints=20, estimator_type="None")
+    x = generate_anomalous_data()
+    x.index = pd.date_range(start="2020-01-01", periods=x.shape[0], freq="D")
     with pytest.raises(NotImplementedError):
         detector.fit(x)
 

--- a/skchange/tests/test_all_interval_evaluators.py
+++ b/skchange/tests/test_all_interval_evaluators.py
@@ -1,12 +1,12 @@
 import numpy as np
+import pandas as pd
 import pytest
-from sktime.utils._testing.annotation import make_annotation_problem
 from sktime.utils.estimator_checks import check_estimator, parametrize_with_checks
 
 from skchange.anomaly_scores import ANOMALY_SCORES
 from skchange.change_scores import CHANGE_SCORES
 from skchange.costs import COSTS
-from skchange.datasets import generate_alternating_data
+from skchange.datasets import generate_alternating_data, generate_anomalous_data
 
 INTERVAL_EVALUATORS = COSTS + CHANGE_SCORES + ANOMALY_SCORES
 
@@ -19,7 +19,8 @@ def test_sktime_compatible_estimators(obj, test_name):
 @pytest.mark.parametrize("Evaluator", INTERVAL_EVALUATORS)
 def test_evaluator_fit(Evaluator):
     evaluator = Evaluator.create_test_instance()
-    x = make_annotation_problem(n_timepoints=50, estimator_type="None")
+    x = generate_anomalous_data()
+    x.index = pd.date_range(start="2020-01-01", periods=x.shape[0], freq="D")
     fit_evaluator = evaluator.fit(x)
     assert fit_evaluator._is_fitted
 
@@ -27,7 +28,8 @@ def test_evaluator_fit(Evaluator):
 @pytest.mark.parametrize("Evaluator", INTERVAL_EVALUATORS)
 def test_evaluator_evaluate(Evaluator):
     evaluator = Evaluator.create_test_instance()
-    x = make_annotation_problem(n_timepoints=50, estimator_type="None")
+    x = generate_anomalous_data()
+    x.index = pd.date_range(start="2020-01-01", periods=x.shape[0], freq="D")
     evaluator.fit(x)
     cut1 = np.linspace(0, 10, evaluator.expected_cut_entries, dtype=int)
 
@@ -76,7 +78,8 @@ def test_evaluator_evaluate_by_evaluation_type(Evaluator):
 @pytest.mark.parametrize("Evaluator", INTERVAL_EVALUATORS)
 def test_evaluator_invalid_cuts(Evaluator):
     evaluator = Evaluator.create_test_instance()
-    x = make_annotation_problem(n_timepoints=50, estimator_type="None")
+    x = generate_anomalous_data()
+    x.index = pd.date_range(start="2020-01-01", periods=x.shape[0], freq="D")
     evaluator.fit(x)
     with pytest.raises(ValueError):
         cut = np.linspace(0, 10, evaluator.expected_cut_entries, dtype=float)


### PR DESCRIPTION
- Update `predict` output according to https://github.com/sktime/sktime/pull/7476. See discussion in https://github.com/sktime/sktime/issues/7323
- Update `transform` output to:

   * Always pd.DataFrame output.
   * ```
            If the detector does not have the capability to identify subsets of
            variables that are affected by the detected events, out output will be a
            `pd.DataFrame` with the same index as X and one column:

            * `"labels"`: Integer labels starting from 0.

            If the detector has this capability, the output will be a `pd.DataFrame`
            with the same index as X and as many columns as there are columns in X
            of the following format:

            * `"labels_<X.columns[i]>"` for each column index i in X.columns: Integer
            labels starting from 0.
   ```

Also:

* Removes the unused `PointAnomalyDetector`.