### PR TITLE
[MNT] Support python 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,13 +24,19 @@ jobs:
 
   pytests-without-numba:
     name: pytests-without-numba
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.13"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
       - name: Run skchange without Numba
         run: |
           python -m pip install --upgrade pip
@@ -53,7 +59,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
       - name: Run skchange with and without Numba
       # Both with and without to get full coverage report.
       # Without numba is very fast, so it doesn't hurt to run it twice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.9,<3.14"
 dependencies = [
   "numpy>=1.21",
   "pandas>=1.1",
-  "sktime>=0.33",
+  "sktime>=0.35",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,15 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 dependencies = [
   "numpy>=1.21",
   "pandas>=1.1",
@@ -52,7 +55,7 @@ numba = [
 # all_extras - all soft dependencies, install via "pip install skchange[all_extras]"
 all_extras = [
   "optuna>=3.1.1",
-  "plotly>=5.13.0",
+  "plotly>=5.13.0; python_version < '3.13'",
   "numba>=0.56",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,6 @@ numba = [
 
 # all_extras - all soft dependencies, install via "pip install skchange[all_extras]"
 all_extras = [
-  "optuna>=3.1.1",
-  "plotly>=5.13.0; python_version < '3.13'",
   "numba>=0.56",
 ]
 


### PR DESCRIPTION
- Support python 3.13
- Delete `optuna` and `plotly` from soft dependencies. Unused so far.
- Improve CI coverage for different python versions. Consider running for all supported python versions and OS's in the future.