### PR TITLE
Require python >= 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: python environment step
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: install pre-commit
         run: python3 -m pip install pre-commit
       - id: changed-files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
+          - "3.10"
           - "3.13"
     runs-on: ubuntu-latest
     steps:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ The library can be installed via pip:
 
     pip install skchange
 
-Requires python versions >= 3.9, < 3.14.
+Requires python versions >= 3.10, < 3.14.
 
 For better computational performance, it is recommended to install skchange with `numba <https://numba.readthedocs.io>`_:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,13 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.10,<3.14"
 dependencies = [
   "numpy>=1.21",
   "pandas>=1.1",

--- a/skchange/anomaly_detectors/anomalisers.py
+++ b/skchange/anomaly_detectors/anomalisers.py
@@ -1,6 +1,6 @@
 """Anomaly detectors composed of change detectors and some conversion logic."""
 
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -48,7 +48,7 @@ class StatThresholdAnomaliser(BaseSegmentAnomalyDetector):
             +f" than or equal to stat_upper ({self.stat_upper})."
             raise ValueError(message)
 
-    def _fit(self, X: pd.DataFrame, y: Optional[pd.DataFrame] = None):
+    def _fit(self, X: pd.DataFrame, y: pd.DataFrame | None = None):
         """Fit to training data.
 
         Parameters
@@ -72,7 +72,7 @@ class StatThresholdAnomaliser(BaseSegmentAnomalyDetector):
         self.change_detector_.fit(X, y)
         return self
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters

--- a/skchange/anomaly_detectors/anomalisers.py
+++ b/skchange/anomaly_detectors/anomalisers.py
@@ -17,7 +17,8 @@ class StatThresholdAnomaliser(BaseSegmentAnomalyDetector):
     change_detector : BaseChangeDetector
         Change detector to use for detecting segments.
     stat : callable, optional (default=np.mean)
-        Statistic to calculate per segment.
+        Statistic to calculate per segment. A function that takes in a 1D array and
+        returns a float.
     stat_lower : float, optional (default=-1.0)
         Segments with a statistic lower than this value are considered anomalous.
     stat_upper : float, optional (default=1.0)
@@ -33,7 +34,7 @@ class StatThresholdAnomaliser(BaseSegmentAnomalyDetector):
     def __init__(
         self,
         change_detector: BaseChangeDetector,
-        stat: Callable = np.mean,
+        stat: Callable[[np.ndarray], float] = np.mean,
         stat_lower: float = -1.0,
         stat_upper: float = 1.0,
     ):

--- a/skchange/anomaly_detectors/base.py
+++ b/skchange/anomaly_detectors/base.py
@@ -15,8 +15,6 @@ Optional to implement:
     _update(self, X, y=None)
 """
 
-from typing import Union
-
 import numpy as np
 import pandas as pd
 
@@ -115,9 +113,7 @@ class BaseSegmentAnomalyDetector(BaseDetector):
 
     def _format_sparse_output(
         self,
-        segment_anomalies: Union[
-            list[tuple[int, int]], list[tuple[int, int, np.ndarray]]
-        ],
+        segment_anomalies: list[tuple[int, int]] | list[tuple[int, int, np.ndarray]],
         closed: str = "left",
     ) -> pd.DataFrame:
         """Format the sparse output of segment anomaly detectors.

--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -3,8 +3,6 @@
 __author__ = ["Tveten"]
 __all__ = ["CAPA"]
 
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 
@@ -119,11 +117,11 @@ class CAPA(BaseSegmentAnomalyDetector):
         minimum size of 1 are permitted.
         If a `BaseCost` is given, the saving function is constructed from the cost. The
         cost must have a fixed parameter that represents the baseline cost.
-    segment_penalty : Union[BasePenalty, float], optional, default=`ChiSquarePenalty`
+    segment_penalty : BasePenalty or float, optional, default=`ChiSquarePenalty`
         The penalty to use for segment anomaly detection. If a float is given, it is
         interpreted as a constant penalty. If `None`, the default penalty is fit to the
         input data to `fit`.
-    point_penalty : Union[BasePenalty, float], optional, default=`ChiSquarePenalty`
+    point_penalty : BasePenalty or float, optional, default=`ChiSquarePenalty`
         The penalty to use for point anomaly detection. If a float is given, it is
         interpreted as a constant penalty. If `None`, the default penalty is fit to the
         input data to `fit`.
@@ -174,10 +172,10 @@ class CAPA(BaseSegmentAnomalyDetector):
 
     def __init__(
         self,
-        segment_saving: Optional[Union[BaseSaving, BaseCost]] = None,
-        point_saving: Optional[Union[BaseSaving, BaseCost]] = None,
-        segment_penalty: Union[BasePenalty, float, None] = None,
-        point_penalty: Union[BasePenalty, float, None] = None,
+        segment_saving: BaseSaving | BaseCost | None = None,
+        point_saving: BaseSaving | BaseCost | None = None,
+        segment_penalty: BasePenalty | float | None = None,
+        point_penalty: BasePenalty | float | None = None,
         min_segment_length: int = 2,
         max_segment_length: int = 1000,
         ignore_point_anomalies: bool = False,
@@ -213,7 +211,7 @@ class CAPA(BaseSegmentAnomalyDetector):
         check_larger_than(2, min_segment_length, "min_segment_length")
         check_larger_than(min_segment_length, max_segment_length, "max_segment_length")
 
-    def _fit(self, X: pd.DataFrame, y: Optional[pd.DataFrame] = None):
+    def _fit(self, X: pd.DataFrame, y: pd.DataFrame | None = None):
         """Fit to training data.
 
         Sets the penalty of the detector.
@@ -250,7 +248,7 @@ class CAPA(BaseSegmentAnomalyDetector):
         self.point_penalty_ = self._point_penalty.fit(X, self._point_saving)
         return self
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters
@@ -288,7 +286,7 @@ class CAPA(BaseSegmentAnomalyDetector):
 
         return self._format_sparse_output(anomalies)
 
-    def _transform_scores(self, X: Union[pd.DataFrame, pd.Series]) -> pd.DataFrame:
+    def _transform_scores(self, X: pd.DataFrame | pd.Series) -> pd.DataFrame:
         """Return scores for predicted labels on test/deployment data.
 
         Parameters

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -3,8 +3,6 @@
 __author__ = ["Tveten"]
 __all__ = ["CircularBinarySegmentation"]
 
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 
@@ -120,7 +118,7 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
     anomaly_score : BaseLocalAnomalyScore or BaseCost, optional, default=L2Cost()
         The local anomaly score to use for anomaly detection. If a cost is given, it is
         converted to a local anomaly score using the `LocalAnomalyScore` class.
-    penalty : Union[BasePenalty, float], optional, default=`BICPenalty`
+    penalty : BasePenalty or float, optional, default=`BICPenalty`
         The penalty to use for the changepoint detection. If a float is given, it is
         interpreted as a constant penalty. If `None`, the penalty is set to a BIC
         penalty with ``n=X.shape[0]`` and
@@ -173,8 +171,8 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
 
     def __init__(
         self,
-        anomaly_score: Optional[Union[BaseCost, BaseLocalAnomalyScore]] = None,
-        penalty: Union[BasePenalty, float, None] = None,
+        anomaly_score: BaseCost | BaseLocalAnomalyScore | None = None,
+        penalty: BasePenalty | float | None = None,
         min_segment_length: int = 5,
         max_interval_length: int = 1000,
         growth_factor: float = 1.5,
@@ -203,7 +201,7 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
             "growth_factor",
         )
 
-    def _fit(self, X: pd.DataFrame, y: Optional[pd.DataFrame] = None):
+    def _fit(self, X: pd.DataFrame, y: pd.DataFrame | None = None):
         """Fit to training data.
 
         Sets the threshold of the detector.
@@ -239,7 +237,7 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
         self.penalty_ = self._penalty.fit(X, self._anomaly_score)
         return self
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters
@@ -279,7 +277,7 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
         return self._format_sparse_output(anomalies)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default"):
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -3,8 +3,6 @@
 __author__ = ["Tveten"]
 __all__ = ["MVCAPA"]
 
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 
@@ -133,10 +131,10 @@ class MVCAPA(BaseSegmentAnomalyDetector):
 
     def __init__(
         self,
-        segment_saving: Optional[Union[BaseSaving, BaseCost]] = None,
-        point_saving: Optional[Union[BaseSaving, BaseCost]] = None,
-        segment_penalty: Union[BasePenalty, np.ndarray, float, None] = None,
-        point_penalty: Union[BasePenalty, np.ndarray, float, None] = None,
+        segment_saving: BaseSaving | BaseCost | None = None,
+        point_saving: BaseSaving | BaseCost | None = None,
+        segment_penalty: BasePenalty | np.ndarray | float | None = None,
+        point_penalty: BasePenalty | np.ndarray | float | None = None,
         min_segment_length: int = 2,
         max_segment_length: int = 1000,
         ignore_point_anomalies: bool = False,
@@ -175,7 +173,7 @@ class MVCAPA(BaseSegmentAnomalyDetector):
         check_larger_than(2, min_segment_length, "min_segment_length")
         check_larger_than(min_segment_length, max_segment_length, "max_segment_length")
 
-    def _fit(self, X: pd.DataFrame, y: Optional[pd.DataFrame] = None):
+    def _fit(self, X: pd.DataFrame, y: pd.DataFrame | None = None):
         """Fit to training data.
 
         Sets the penalty of the detector.
@@ -212,7 +210,7 @@ class MVCAPA(BaseSegmentAnomalyDetector):
         self.point_penalty_ = self._point_penalty.fit(X, self._point_saving)
         return self
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters
@@ -250,7 +248,7 @@ class MVCAPA(BaseSegmentAnomalyDetector):
 
         return self._format_sparse_output(anomalies)
 
-    def _transform_scores(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _transform_scores(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Return scores for predicted labels on test/deployment data.
 
         Parameters

--- a/skchange/anomaly_scores/from_cost.py
+++ b/skchange/anomaly_scores/from_cost.py
@@ -1,7 +1,5 @@
 """Saving-type anomaly scores."""
 
-from typing import Union
-
 import numpy as np
 
 from skchange.anomaly_scores.base import BaseLocalAnomalyScore, BaseSaving
@@ -10,7 +8,7 @@ from skchange.utils.validation.cuts import check_cuts_array
 from skchange.utils.validation.data import as_2d_array
 
 
-def to_saving(scorer: Union[BaseCost, BaseSaving]) -> BaseSaving:
+def to_saving(scorer: BaseCost | BaseSaving) -> BaseSaving:
     """Convert compatible scorers to a saving.
 
     Parameters
@@ -152,7 +150,7 @@ class Saving(BaseSaving):
 
 
 def to_local_anomaly_score(
-    scorer: Union[BaseCost, BaseLocalAnomalyScore],
+    scorer: BaseCost | BaseLocalAnomalyScore,
 ) -> BaseLocalAnomalyScore:
     """Convert compatible scorers to a saving.
 

--- a/skchange/base/base_interval_scorer.py
+++ b/skchange/base/base_interval_scorer.py
@@ -14,8 +14,6 @@ Needs to be implemented for a concrete detector:
 __author__ = ["Tveten", "johannvk", "fkiraly"]
 __all__ = ["BaseIntervalScorer"]
 
-from typing import Union
-
 import numpy as np
 from numpy.typing import ArrayLike
 from sktime.base import BaseEstimator
@@ -163,7 +161,7 @@ class BaseIntervalScorer(BaseEstimator):
         raise NotImplementedError("abstract method")
 
     @property
-    def min_size(self) -> Union[int, None]:
+    def min_size(self) -> int | None:
         """Minimum valid size of an interval to evaluate.
 
         The size of each interval is by default defined as ``np.diff(cuts[i, ])``.

--- a/skchange/change_detectors/moving_window.py
+++ b/skchange/change_detectors/moving_window.py
@@ -3,8 +3,6 @@
 __author__ = ["Tveten"]
 __all__ = ["MovingWindow"]
 
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 
@@ -64,7 +62,7 @@ class MovingWindow(BaseChangeDetector):
     change_score : BaseChangeScore or BaseCost, optional, default=`CUSUM()`
         The change score to use in the algorithm. If a cost function is given, it is
         converted to a change score using the `ChangeScore` class.
-    penalty : Union[BasePenalty, float], optional, default=`BICPenalty`
+    penalty : BasePenalty or float, optional, default=`BICPenalty`
         The penalty to use for the changepoint detection. If a float is given, it is
         interpreted as a constant penalty. If `None`, the penalty is set to a BIC
         penalty with ``n=X.shape[0]`` and
@@ -105,8 +103,8 @@ class MovingWindow(BaseChangeDetector):
 
     def __init__(
         self,
-        change_score: Optional[Union[BaseChangeScore, BaseCost]] = None,
-        penalty: Union[BasePenalty, float, None] = None,
+        change_score: BaseChangeScore | BaseCost | None = None,
+        penalty: BasePenalty | float | None = None,
         bandwidth: int = 30,
         min_detection_interval: int = 1,
     ):
@@ -130,7 +128,7 @@ class MovingWindow(BaseChangeDetector):
             "min_detection_interval",
         )
 
-    def _fit(self, X: pd.DataFrame, y: Optional[pd.DataFrame] = None):
+    def _fit(self, X: pd.DataFrame, y: pd.DataFrame | None = None):
         """Fit to training data.
 
         Sets the threshold of the detector.
@@ -169,7 +167,7 @@ class MovingWindow(BaseChangeDetector):
         self.penalty_ = self._penalty.fit(X, self._change_score)
         return self
 
-    def _transform_scores(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _transform_scores(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Return scores for predicted labels on test/deployment data.
 
         Parameters
@@ -194,7 +192,7 @@ class MovingWindow(BaseChangeDetector):
         )
         return pd.Series(scores, index=X.index, name="score")
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters
@@ -215,7 +213,7 @@ class MovingWindow(BaseChangeDetector):
         return self._format_sparse_output(changepoints)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default"):
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -3,9 +3,6 @@
 __author__ = ["Tveten", "johannvk"]
 __all__ = ["PELT"]
 
-
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 
@@ -126,7 +123,7 @@ class PELT(BaseChangeDetector):
     ----------
     cost : BaseCost, optional, default=`L2Cost`
         The cost function to use for the changepoint detection.
-    penalty : Union[BasePenalty, float], optional, default=`BICPenalty`
+    penalty : BasePenalty or float, optional, default=`BICPenalty`
         The penalty to use for the changepoint detection. If a float is given, it is
         interpreted as a constant penalty. If `None`, the penalty is set to a BIC
         penalty with ``n=X.shape[0]`` and ``n_params=cost.get_param_size(X.shape[1])``,
@@ -159,7 +156,7 @@ class PELT(BaseChangeDetector):
     def __init__(
         self,
         cost: BaseCost = None,
-        penalty: Union[BasePenalty, float, None] = None,
+        penalty: BasePenalty | float | None = None,
         min_segment_length: int = 2,
     ):
         self.cost = cost
@@ -175,8 +172,8 @@ class PELT(BaseChangeDetector):
 
     def _fit(
         self,
-        X: Union[pd.Series, pd.DataFrame],
-        y: Optional[Union[pd.Series, pd.DataFrame]] = None,
+        X: pd.Series | pd.DataFrame,
+        y: pd.Series | pd.DataFrame | None = None,
     ):
         """Fit to training data.
 
@@ -213,7 +210,7 @@ class PELT(BaseChangeDetector):
         self.penalty_ = self._penalty.fit(X, self._cost)
         return self
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters
@@ -242,7 +239,7 @@ class PELT(BaseChangeDetector):
         self.scores = pd.Series(opt_costs, index=X.index, name="score")
         return self._format_sparse_output(changepoints)
 
-    def _transform_scores(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _transform_scores(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Return scores for predicted labels on test/deployment data.
 
         Parameters

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -3,8 +3,6 @@
 __author__ = ["Tveten"]
 __all__ = ["SeededBinarySegmentation"]
 
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 
@@ -109,7 +107,7 @@ class SeededBinarySegmentation(BaseChangeDetector):
     change_score : BaseChangeScore or BaseCost, optional, default=CUSUM()
         The change score to use in the algorithm. If a cost function is given, it is
         converted to a change score using the `ChangeScore` class.
-    penalty : Union[BasePenalty, float], optional, default=`BICPenalty`
+    penalty : BasePenalty or float, optional, default=`BICPenalty`
         The penalty to use for the changepoint detection. If a float is given, it is
         interpreted as a constant penalty. If `None`, the penalty is set to a BIC
         penalty with ``n=X.shape[0]`` and
@@ -156,8 +154,8 @@ class SeededBinarySegmentation(BaseChangeDetector):
 
     def __init__(
         self,
-        change_score: Optional[Union[BaseChangeScore, BaseCost]] = None,
-        penalty: Union[BasePenalty, float, None] = None,
+        change_score: BaseChangeScore | BaseCost | None = None,
+        penalty: BasePenalty | float | None = None,
         min_segment_length: int = 5,
         max_interval_length: int = 200,
         growth_factor: float = 1.5,
@@ -186,7 +184,7 @@ class SeededBinarySegmentation(BaseChangeDetector):
             "growth_factor",
         )
 
-    def _fit(self, X: pd.DataFrame, y: Optional[pd.DataFrame] = None):
+    def _fit(self, X: pd.DataFrame, y: pd.DataFrame | None = None):
         """Fit to training data.
 
         Sets the threshold of the detector.
@@ -225,7 +223,7 @@ class SeededBinarySegmentation(BaseChangeDetector):
         self.penalty_ = self._penalty.fit(X, self._change_score)
         return self
 
-    def _predict(self, X: Union[pd.DataFrame, pd.Series]) -> pd.Series:
+    def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.
 
         Parameters

--- a/skchange/change_scores/from_cost.py
+++ b/skchange/change_scores/from_cost.py
@@ -1,14 +1,12 @@
 """Cost-based change scores."""
 
-from typing import Union
-
 import numpy as np
 
 from skchange.change_scores.base import BaseChangeScore
 from skchange.costs.base import BaseCost
 
 
-def to_change_score(scorer: Union[BaseCost, BaseChangeScore]) -> BaseChangeScore:
+def to_change_score(scorer: BaseCost | BaseChangeScore) -> BaseChangeScore:
     """Convert compatible scorers to a change score.
 
     Parameters

--- a/skchange/costs/gaussian_cost.py
+++ b/skchange/costs/gaussian_cost.py
@@ -2,8 +2,6 @@
 
 __author__ = ["Tveten"]
 
-from typing import Union
-
 import numpy as np
 
 from skchange.costs.base import BaseCost
@@ -127,7 +125,7 @@ class GaussianCost(BaseCost):
         If ``None``, the maximum likelihood estimates are used.
     """
 
-    def __init__(self, param: Union[tuple[MeanType, VarType], None] = None):
+    def __init__(self, param: tuple[MeanType, VarType] | None = None):
         super().__init__(param)
 
     def _check_fixed_param(

--- a/skchange/costs/l2_cost.py
+++ b/skchange/costs/l2_cost.py
@@ -1,7 +1,5 @@
 """L2 cost."""
 
-from typing import Union
-
 import numpy as np
 
 from skchange.costs.base import BaseCost
@@ -93,7 +91,7 @@ class L2Cost(BaseCost):
         calculated.
     """
 
-    def __init__(self, param: Union[MeanType, None] = None):
+    def __init__(self, param: MeanType | None = None):
         super().__init__(param)
 
     def _check_fixed_param(self, param: MeanType, X: np.ndarray) -> np.ndarray:

--- a/skchange/costs/multivariate_gaussian_cost.py
+++ b/skchange/costs/multivariate_gaussian_cost.py
@@ -3,8 +3,6 @@
 __author__ = ["johannvk", "Tveten"]
 __all__ = ["MultivariateGaussianCost"]
 
-from typing import Union
-
 import numpy as np
 
 from skchange.costs.base import BaseCost
@@ -183,7 +181,7 @@ class MultivariateGaussianCost(BaseCost):
 
     evaluation_type = "multivariate"
 
-    def __init__(self, param: Union[tuple[MeanType, CovType], None] = None):
+    def __init__(self, param: tuple[MeanType, CovType] | None = None):
         super().__init__(param)
 
     def _check_fixed_param(
@@ -209,7 +207,7 @@ class MultivariateGaussianCost(BaseCost):
         return mean, cov
 
     @property
-    def min_size(self) -> Union[int, None]:
+    def min_size(self) -> int | None:
         """Minimum size of the interval to evaluate.
 
         The size of each interval is defined as ``cuts[i, 1] - cuts[i, 0]``.

--- a/skchange/costs/utils.py
+++ b/skchange/costs/utils.py
@@ -1,14 +1,13 @@
 """Utility functions for cost calculations."""
 
 import numbers
-from typing import Union
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-MeanType = Union[ArrayLike, numbers.Number]
-VarType = Union[ArrayLike, numbers.Number]
-CovType = Union[ArrayLike, numbers.Number]
+MeanType = ArrayLike | numbers.Number
+VarType = ArrayLike | numbers.Number
+CovType = ArrayLike | numbers.Number
 
 
 def check_mean(mean: MeanType, X: np.ndarray) -> np.ndarray:

--- a/skchange/datasets/generate.py
+++ b/skchange/datasets/generate.py
@@ -3,7 +3,6 @@
 __author__ = ["Tveten"]
 
 from numbers import Number
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -12,9 +11,9 @@ from scipy.stats import multivariate_normal
 
 def generate_changing_data(
     n: int = 100,
-    changepoints: Union[int, list[int]] = 50,
-    means: Union[float, list[float], list[np.ndarray]] = 0.0,
-    variances: Union[float, list[float], list[np.ndarray]] = 1.0,
+    changepoints: int | list[int] = 50,
+    means: float | list[float] | list[np.ndarray] = 0.0,
+    variances: float | list[float] | list[np.ndarray] = 1.0,
     random_state: int = None,
 ):
     """
@@ -80,9 +79,9 @@ def generate_changing_data(
 
 def generate_anomalous_data(
     n: int = 100,
-    anomalies: Union[tuple[int, int], list[tuple[int, int]]] = (70, 80),
-    means: Union[float, list[float], list[np.ndarray]] = 3.0,
-    variances: Union[float, list[float], list[np.ndarray]] = 1.0,
+    anomalies: tuple[int, int] | list[tuple[int, int]] = (70, 80),
+    means: float | list[float] | list[np.ndarray] = 3.0,
+    variances: float | list[float] | list[np.ndarray] = 1.0,
     random_state: int = None,
 ) -> pd.DataFrame:
     """

--- a/skchange/penalties/base.py
+++ b/skchange/penalties/base.py
@@ -1,7 +1,5 @@
 """Base class for penalties and penalty functions."""
 
-from typing import Union
-
 import numpy as np
 import pandas as pd
 from sktime.base import BaseEstimator
@@ -43,7 +41,7 @@ class BasePenalty(BaseEstimator):
             raise ValueError("scale must be non-negative")
 
     def fit(
-        self, X: Union[pd.DataFrame, pd.Series, np.ndarray], scorer: BaseIntervalScorer
+        self, X: pd.DataFrame | pd.Series | np.ndarray, scorer: BaseIntervalScorer
     ) -> "BasePenalty":
         """Fit the penalty to data and a scorer.
 
@@ -97,7 +95,7 @@ class BasePenalty(BaseEstimator):
         return self.scale * base_values
 
     @property
-    def _base_values(self) -> Union[np.ndarray, float]:
+    def _base_values(self) -> np.ndarray | float:
         """Get the base penalty values.
 
         Returns
@@ -115,7 +113,7 @@ class BasePenalty(BaseEstimator):
         raise NotImplementedError("abstract method")
 
     def _fit(
-        self, X: Union[pd.DataFrame, pd.Series, np.ndarray], scorer: BaseIntervalScorer
+        self, X: pd.DataFrame | pd.Series | np.ndarray, scorer: BaseIntervalScorer
     ) -> "BasePenalty":
         """Fit the penalty to data and a scorer.
 

--- a/skchange/penalties/composition.py
+++ b/skchange/penalties/composition.py
@@ -1,7 +1,5 @@
 """Composite penalties for change and anomaly detection."""
 
-from typing import Union
-
 import numpy as np
 import pandas as pd
 
@@ -42,7 +40,7 @@ class MinimumPenalty(BasePenalty):
             self.penalty_type = "constant"
 
     def _fit(
-        self, X: Union[pd.DataFrame, pd.Series, np.ndarray], scorer: BaseIntervalScorer
+        self, X: pd.DataFrame | pd.Series | np.ndarray, scorer: BaseIntervalScorer
     ) -> "BasePenalty":
         """Fit the penalty to data and a scorer.
 

--- a/skchange/penalties/conversion.py
+++ b/skchange/penalties/conversion.py
@@ -1,7 +1,6 @@
 """Utilities for converting objects to penalties."""
 
 import numbers
-from typing import Union
 
 import numpy as np
 
@@ -12,7 +11,7 @@ from skchange.penalties.nonlinear_penalties import NonlinearPenalty
 
 
 def as_penalty(
-    x: Union[BasePenalty, np.ndarray, tuple[float, float], float, None],
+    x: BasePenalty | np.ndarray | tuple[float, float] | float | None,
     default: BasePenalty = None,
     require_penalty_type: str = None,
 ):

--- a/skchange/penalties/nonlinear_penalties.py
+++ b/skchange/penalties/nonlinear_penalties.py
@@ -1,7 +1,5 @@
 """Non-linear penalties for change and anomaly detection."""
 
-from typing import Union
-
 import numpy as np
 import pandas as pd
 from scipy.stats import chi2
@@ -45,7 +43,7 @@ class NonlinearPenalty(BasePenalty):
         check_penalty_array(self.base_values)
 
     def _fit(
-        self, X: Union[pd.DataFrame, pd.Series, np.ndarray], scorer: BaseIntervalScorer
+        self, X: pd.DataFrame | pd.Series | np.ndarray, scorer: BaseIntervalScorer
     ) -> "BasePenalty":
         """Fit the penalty to data and a scorer.
 
@@ -150,7 +148,7 @@ class NonlinearChiSquarePenalty(BasePenalty):
         super().__init__(scale)
 
     def _fit(
-        self, X: Union[pd.DataFrame, pd.Series, np.ndarray], scorer: BaseIntervalScorer
+        self, X: pd.DataFrame | pd.Series | np.ndarray, scorer: BaseIntervalScorer
     ) -> "BasePenalty":
         """Fit the penalty to data and a scorer.
 

--- a/skchange/utils/validation/data.py
+++ b/skchange/utils/validation/data.py
@@ -1,13 +1,11 @@
 """Validation functions for input data series."""
 
-from typing import Union
-
 import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
 
 
-def to_data_frame(X: Union[pd.DataFrame, pd.Series, ArrayLike]):
+def to_data_frame(X: pd.DataFrame | pd.Series | ArrayLike) -> pd.DataFrame:
     """Convert input data to a pd.DataFrame."""
     if isinstance(X, np.ndarray):
         X = pd.DataFrame(X)
@@ -17,7 +15,7 @@ def to_data_frame(X: Union[pd.DataFrame, pd.Series, ArrayLike]):
 
 
 def check_data(
-    X: Union[pd.DataFrame, pd.Series, np.ndarray],
+    X: pd.DataFrame | pd.Series | np.ndarray,
     min_length: int,
     min_length_name: str = "min_length",
     allow_missing_values: bool = False,


### PR DESCRIPTION
- Remove support for python 3.9. 
- Fixes https://github.com/NorskRegnesentral/skchange/issues/56

Python 3.10 improves type hinting, and libraries like `numpy` does not support python 3.9 anymore.