### PR TITLE
Lift fitting of costs: From within algorithm implementation, to ChangeDetector

### DIFF
--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -36,27 +36,23 @@ def get_anomalies(
 
 
 def run_capa(
-    X: np.ndarray,
-    segment_saving: BaseSaving,
-    point_saving: BaseSaving,
-    segment_penalty: BasePenalty,
-    point_penalty: BasePenalty,
+    segment_penalised_saving: PenalisedScore,
+    point_penalised_saving: PenalisedScore,
+    num_observations: int,
     min_segment_length: int,
     max_segment_length: int,
 ) -> tuple[np.ndarray, list[tuple[int, int]], list[tuple[int, int]]]:
-    segment_penalised_saving = PenalisedScore(segment_saving, segment_penalty)
-    point_penalised_saving = PenalisedScore(point_saving, point_penalty)
-    segment_penalised_saving.fit(X)
-    point_penalised_saving.fit(X)
+    segment_penalised_saving.check_is_fitted()
+    point_penalised_saving.check_is_fitted()
 
-    n = segment_penalised_saving._X.shape[0]
-    opt_savings = np.zeros(n + 1)
+    # num_observations = segment_penalised_saving._X.shape[0]
+    opt_savings = np.zeros(num_observations + 1)
     # Store the optimal start and affected components of an anomaly for each t.
     # Used to get the final set of anomalies after the loop.
-    opt_anomaly_starts = np.repeat(np.nan, n)
+    opt_anomaly_starts = np.repeat(np.nan, num_observations)
     starts = np.array([], dtype=int)
 
-    ts = np.arange(min_segment_length - 1, n)
+    ts = np.arange(min_segment_length - 1, num_observations)
     for t in ts:
         # Segment anomalies
         t_array = np.array([t])
@@ -246,6 +242,7 @@ class CAPA(BaseSegmentAnomalyDetector):
         )
         self.segment_penalty_ = self._segment_penalty.fit(X, self._segment_saving)
         self.point_penalty_ = self._point_penalty.fit(X, self._point_saving)
+
         return self
 
     def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
@@ -268,14 +265,22 @@ class CAPA(BaseSegmentAnomalyDetector):
             min_length=self.min_segment_length,
             min_length_name="min_segment_length",
         )
+        num_observations = X.shape[0]
+
+        segment_penalised_saving = PenalisedScore(
+            self._segment_saving, self.segment_penalty_
+        )
+        segment_penalised_saving.fit(X)
+
+        point_penalised_saving = PenalisedScore(self._point_saving, self.point_penalty_)
+        point_penalised_saving.fit(X)
+
         opt_savings, segment_anomalies, point_anomalies = run_capa(
-            X.values,
-            self._segment_saving,
-            self._point_saving,
-            self.segment_penalty_,
-            self.point_penalty_,
-            self.min_segment_length,
-            self.max_segment_length,
+            segment_penalised_saving=segment_penalised_saving,
+            point_penalised_saving=point_penalised_saving,
+            num_observations=num_observations,
+            min_segment_length=self.min_segment_length,
+            max_segment_length=self.max_segment_length,
         )
         self.scores = pd.Series(opt_savings, index=X.index, name="score")
 

--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -38,21 +38,25 @@ def get_anomalies(
 def run_capa(
     segment_penalised_saving: PenalisedScore,
     point_penalised_saving: PenalisedScore,
-    num_observations: int,
     min_segment_length: int,
     max_segment_length: int,
 ) -> tuple[np.ndarray, list[tuple[int, int]], list[tuple[int, int]]]:
     segment_penalised_saving.check_is_fitted()
     point_penalised_saving.check_is_fitted()
+    n_samples = segment_penalised_saving._X.shape[0]
+    if not n_samples == point_penalised_saving._X.shape[0]:
+        raise ValueError(
+            "The segment and point saving costs must span the same number of samples."
+        )
 
     # num_observations = segment_penalised_saving._X.shape[0]
-    opt_savings = np.zeros(num_observations + 1)
+    opt_savings = np.zeros(n_samples + 1)
     # Store the optimal start and affected components of an anomaly for each t.
     # Used to get the final set of anomalies after the loop.
-    opt_anomaly_starts = np.repeat(np.nan, num_observations)
+    opt_anomaly_starts = np.repeat(np.nan, n_samples)
     starts = np.array([], dtype=int)
 
-    ts = np.arange(min_segment_length - 1, num_observations)
+    ts = np.arange(min_segment_length - 1, n_samples)
     for t in ts:
         # Segment anomalies
         t_array = np.array([t])
@@ -265,7 +269,6 @@ class CAPA(BaseSegmentAnomalyDetector):
             min_length=self.min_segment_length,
             min_length_name="min_segment_length",
         )
-        num_observations = X.shape[0]
 
         segment_penalised_saving = PenalisedScore(
             self._segment_saving, self.segment_penalty_
@@ -278,7 +281,6 @@ class CAPA(BaseSegmentAnomalyDetector):
         opt_savings, segment_anomalies, point_anomalies = run_capa(
             segment_penalised_saving=segment_penalised_saving,
             point_penalised_saving=point_penalised_saving,
-            num_observations=num_observations,
             min_segment_length=self.min_segment_length,
             max_segment_length=self.max_segment_length,
         )

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -57,7 +57,6 @@ def make_anomaly_intervals(
 
 
 def run_circular_binseg(
-    num_observations: int,
     score: BaseLocalAnomalyScore,
     threshold: float,
     min_segment_length: int,
@@ -65,8 +64,10 @@ def run_circular_binseg(
     growth_factor: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     score.check_is_fitted()
+    n_samples = score._X.shape[0]
+
     starts, ends = make_seeded_intervals(
-        num_observations,
+        n_samples,
         2 * min_segment_length,
         max_interval_length,
         growth_factor,
@@ -257,12 +258,8 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="min_interval_length",
         )
-
-        num_observations = X.shape[0]
         self._anomaly_score.fit(X)
-
         anomalies, scores, maximizers, starts, ends = run_circular_binseg(
-            num_observations=num_observations,
             score=self._anomaly_score,
             threshold=self.penalty_.values[0],
             min_segment_length=self.min_segment_length,

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -57,20 +57,20 @@ def make_anomaly_intervals(
 
 
 def run_circular_binseg(
-    X: np.ndarray,
+    num_observations: int,
     score: BaseLocalAnomalyScore,
     threshold: float,
     min_segment_length: int,
     max_interval_length: int,
     growth_factor: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    score.check_is_fitted()
     starts, ends = make_seeded_intervals(
-        X.shape[0],
+        num_observations,
         2 * min_segment_length,
         max_interval_length,
         growth_factor,
     )
-    score.fit(X)
 
     anomaly_scores = np.zeros(starts.size)
     anomaly_starts = np.zeros(starts.size, dtype=np.int64)
@@ -257,14 +257,19 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="min_interval_length",
         )
+
+        num_observations = X.shape[0]
+        self._anomaly_score.fit(X)
+
         anomalies, scores, maximizers, starts, ends = run_circular_binseg(
-            X.values,
-            self._anomaly_score,
-            self.penalty_.values[0],
-            self.min_segment_length,
-            self.max_interval_length,
-            self.growth_factor,
+            num_observations=num_observations,
+            score=self._anomaly_score,
+            threshold=self.penalty_.values[0],
+            min_segment_length=self.min_segment_length,
+            max_interval_length=self.max_interval_length,
+            growth_factor=self.growth_factor,
         )
+
         self.scores = pd.DataFrame(
             {
                 "interval_start": starts,

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -43,7 +43,6 @@ def find_affected_components(
 def run_mvcapa(
     segment_penalised_saving: PenalisedScore,
     point_penalised_saving: PenalisedScore,
-    num_observations: int,
     min_segment_length: int,
     max_segment_length: int,
 ) -> tuple[
@@ -52,7 +51,6 @@ def run_mvcapa(
     opt_savings, segment_anomalies, point_anomalies = run_capa(
         segment_penalised_saving=segment_penalised_saving,
         point_penalised_saving=point_penalised_saving,
-        num_observations=num_observations,
         min_segment_length=min_segment_length,
         max_segment_length=max_segment_length,
     )
@@ -231,7 +229,6 @@ class MVCAPA(BaseSegmentAnomalyDetector):
             min_length=self.min_segment_length,
             min_length_name="min_segment_length",
         )
-        num_observations = X.shape[0]
 
         segment_penalised_saving = PenalisedScore(
             scorer=self._segment_saving, penalty=self.segment_penalty_
@@ -243,7 +240,6 @@ class MVCAPA(BaseSegmentAnomalyDetector):
         opt_savings, segment_anomalies, point_anomalies = run_mvcapa(
             segment_penalised_saving=segment_penalised_saving,
             point_penalised_saving=point_penalised_saving,
-            num_observations=num_observations,
             min_segment_length=self.min_segment_length,
             max_segment_length=self.max_segment_length,
         )

--- a/skchange/anomaly_detectors/mvcapa.py
+++ b/skchange/anomaly_detectors/mvcapa.py
@@ -61,7 +61,8 @@ def run_mvcapa(
         segment_penalised_saving, segment_anomalies
     )
     point_anomalies = find_affected_components(
-        point_penalised_saving, point_anomalies,
+        point_penalised_saving,
+        point_anomalies,
     )
     return opt_savings, segment_anomalies, point_anomalies
 

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -26,8 +26,8 @@ def get_changepoints(prev_cpts: np.ndarray) -> np.ndarray:
 
 
 def run_pelt(
-    X: np.ndarray,
     cost: BaseCost,
+    num_obs: int,
     penalty: float,
     min_segment_length: int = 1,
     split_cost: float = 0.0,
@@ -62,8 +62,7 @@ def run_pelt(
     tuple[np.ndarray, list]
         The optimal costs and the changepoints.
     """
-    num_obs = len(X)
-    cost.fit(X)
+    cost.check_is_fitted()
     min_segment_shift = min_segment_length - 1
 
     # Explicitly set the first element to -penalty.
@@ -229,11 +228,13 @@ class PELT(BaseChangeDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="2*min_segment_length",
         )
+        self._cost.fit(X)
+
         opt_costs, changepoints = run_pelt(
-            X.values,
-            self._cost,
-            self.penalty_.values[0],
-            self.min_segment_length,
+            cost=self._cost,
+            num_obs=X.shape[0],
+            penalty=self.penalty_.values[0],
+            min_segment_length=self.min_segment_length,
         )
         # Store the scores for introspection without recomputing using transform_scores
         self.scores = pd.Series(opt_costs, index=X.index, name="score")

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -27,9 +27,8 @@ def get_changepoints(prev_cpts: np.ndarray) -> np.ndarray:
 
 def run_pelt(
     cost: BaseCost,
-    num_obs: int,
     penalty: float,
-    min_segment_length: int = 1,
+    min_segment_length: int,
     split_cost: float = 0.0,
 ) -> tuple[np.ndarray, list]:
     """Run the PELT algorithm.
@@ -47,7 +46,7 @@ def run_pelt(
         The cost to use.
     penalty : float
         The penalty incurred for adding a changepoint.
-    min_segment_length : int, optional
+    min_segment_length : int
         The minimum length of a segment, by default 1.
     split_cost : float, optional
         The cost of splitting a segment, to ensure that
@@ -63,10 +62,11 @@ def run_pelt(
         The optimal costs and the changepoints.
     """
     cost.check_is_fitted()
+    n_samples = cost._X.shape[0]
     min_segment_shift = min_segment_length - 1
 
     # Explicitly set the first element to -penalty.
-    opt_cost = np.concatenate((np.array([-penalty]), np.zeros(num_obs)))
+    opt_cost = np.concatenate((np.array([-penalty]), np.zeros(n_samples)))
 
     # Cannot compute the cost for the first 'min_segment_shift' elements:
     opt_cost[1:min_segment_length] = -penalty
@@ -83,12 +83,12 @@ def run_pelt(
 
     # Store the previous changepoint for each latest start added.
     # Used to get the final set of changepoints after the loop.
-    prev_cpts = np.repeat(0, num_obs)
+    prev_cpts = np.repeat(0, n_samples)
 
     # Evolving set of admissible segment starts.
     cost_eval_starts = np.array(([0]), dtype=np.int64)
 
-    observation_indices = np.arange(2 * min_segment_length - 1, num_obs).reshape(-1, 1)
+    observation_indices = np.arange(2 * min_segment_length - 1, n_samples).reshape(-1, 1)
     for current_obs_ind in observation_indices:
         latest_start = current_obs_ind - min_segment_shift
 
@@ -129,6 +129,12 @@ class PELT(BaseChangeDetector):
         where ``X`` is the input data to `fit`.
     min_segment_length : int, optional, default=2
         Minimum length of a segment.
+    split_cost : float, optional, default=0.0
+        The cost of splitting a segment, to ensure that
+        cost(X[t:p]) + cost(X[p:(s+1)]) + split_cost <= cost(X[t:(s+1)]),
+        for all possible splits, 0 <= t < p < s <= len(X) - 1.
+        By default set to 0.0, which is sufficient for
+        log likelihood cost functions to satisfy the above inequality.
 
     References
     ----------
@@ -157,10 +163,12 @@ class PELT(BaseChangeDetector):
         cost: BaseCost = None,
         penalty: BasePenalty | float | None = None,
         min_segment_length: int = 2,
+        split_cost: float = 0.0,
     ):
         self.cost = cost
         self.penalty = penalty
         self.min_segment_length = min_segment_length
+        self.split_cost = split_cost
         super().__init__()
 
         self._cost = L2Cost() if cost is None else cost
@@ -229,12 +237,11 @@ class PELT(BaseChangeDetector):
             min_length_name="2*min_segment_length",
         )
         self._cost.fit(X)
-
         opt_costs, changepoints = run_pelt(
             cost=self._cost,
-            num_obs=X.shape[0],
             penalty=self.penalty_.values[0],
             min_segment_length=self.min_segment_length,
+            split_cost=self.split_cost
         )
         # Store the scores for introspection without recomputing using transform_scores
         self.scores = pd.Series(opt_costs, index=X.index, name="score")

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -88,7 +88,9 @@ def run_pelt(
     # Evolving set of admissible segment starts.
     cost_eval_starts = np.array(([0]), dtype=np.int64)
 
-    observation_indices = np.arange(2 * min_segment_length - 1, n_samples).reshape(-1, 1)
+    observation_indices = np.arange(2 * min_segment_length - 1, n_samples).reshape(
+        -1, 1
+    )
     for current_obs_ind in observation_indices:
         latest_start = current_obs_ind - min_segment_shift
 
@@ -241,7 +243,7 @@ class PELT(BaseChangeDetector):
             cost=self._cost,
             penalty=self.penalty_.values[0],
             min_segment_length=self.min_segment_length,
-            split_cost=self.split_cost
+            split_cost=self.split_cost,
         )
         # Store the scores for introspection without recomputing using transform_scores
         self.scores = pd.Series(opt_costs, index=X.index, name="score")

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -58,20 +58,21 @@ def greedy_changepoint_selection(
 
 
 def run_seeded_binseg(
-    X: np.ndarray,
     change_score: BaseChangeScore,
+    num_observations: int,
     threshold: float,
     min_segment_length: int,
     max_interval_length: int,
     growth_factor: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    change_score.check_is_fitted()
+
     starts, ends = make_seeded_intervals(
-        X.shape[0],
+        num_observations,
         2 * min_segment_length,
         max_interval_length,
         growth_factor,
     )
-    change_score.fit(X)
 
     amoc_scores = np.zeros(starts.size)
     maximizers = np.zeros(starts.size, dtype=np.int64)
@@ -242,13 +243,15 @@ class SeededBinarySegmentation(BaseChangeDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="min_interval_length",
         )
+        self._change_score.fit(X)
+        num_observations = X.shape[0]
         cpts, scores, maximizers, starts, ends = run_seeded_binseg(
-            X.values,
-            self._change_score,
-            self.penalty_.values[0],
-            self.min_segment_length,
-            self.max_interval_length,
-            self.growth_factor,
+            change_score=self._change_score,
+            num_observations=num_observations,
+            threshold=self.penalty_.values[0],
+            min_segment_length=self.min_segment_length,
+            max_interval_length=self.max_interval_length,
+            growth_factor=self.growth_factor,
         )
         self.scores = pd.DataFrame(
             {"start": starts, "end": ends, "argmax_cpt": maximizers, "score": scores}

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -59,16 +59,16 @@ def greedy_changepoint_selection(
 
 def run_seeded_binseg(
     change_score: BaseChangeScore,
-    num_observations: int,
     threshold: float,
     min_segment_length: int,
     max_interval_length: int,
     growth_factor: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     change_score.check_is_fitted()
+    n_samples = change_score._X.shape[0]
 
     starts, ends = make_seeded_intervals(
-        num_observations,
+        n_samples,
         2 * min_segment_length,
         max_interval_length,
         growth_factor,
@@ -244,10 +244,8 @@ class SeededBinarySegmentation(BaseChangeDetector):
             min_length_name="min_interval_length",
         )
         self._change_score.fit(X)
-        num_observations = X.shape[0]
         cpts, scores, maximizers, starts, ends = run_seeded_binseg(
             change_score=self._change_score,
-            num_observations=num_observations,
             threshold=self.penalty_.values[0],
             min_segment_length=self.min_segment_length,
             max_interval_length=self.max_interval_length,


### PR DESCRIPTION
To separate concerns this PR lifts the fitting of the costs and related objects used by `ChangeDetector`s from the respective methods implementing the change detection algorithms, up to the internal `ChangeDetector._predict(self, X)` methods.

This hopefully makes the dependencies between different components of the change detection pipeline more clearly visible.