### PR TITLE
Fix fitted penalty

### DIFF
--- a/skchange/anomaly_detectors/capa.py
+++ b/skchange/anomaly_detectors/capa.py
@@ -244,8 +244,10 @@ class CAPA(BaseSegmentAnomalyDetector):
             min_length=self.min_segment_length,
             min_length_name="min_segment_length",
         )
-        self.segment_penalty_ = self._segment_penalty.fit(X, self._segment_saving)
-        self.point_penalty_ = self._point_penalty.fit(X, self._point_saving)
+        self.segment_penalty_: BasePenalty = self._segment_penalty.clone()
+        self.point_penalty_: BasePenalty = self._point_penalty.clone()
+        self.segment_penalty_.fit(X, self._segment_saving)
+        self.point_penalty_.fit(X, self._point_saving)
 
         return self
 

--- a/skchange/anomaly_detectors/circular_binseg.py
+++ b/skchange/anomaly_detectors/circular_binseg.py
@@ -235,7 +235,8 @@ class CircularBinarySegmentation(BaseSegmentAnomalyDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="min_interval_length",
         )
-        self.penalty_ = self._penalty.fit(X, self._anomaly_score)
+        self.penalty_: BasePenalty = self._penalty.clone()
+        self.penalty_.fit(X, self._anomaly_score)
         return self
 
     def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:

--- a/skchange/change_detectors/moving_window.py
+++ b/skchange/change_detectors/moving_window.py
@@ -163,7 +163,10 @@ class MovingWindow(BaseChangeDetector):
             min_length=2 * self.bandwidth,
             min_length_name="2*bandwidth",
         )
-        self.penalty_ = self._penalty.fit(X, self._change_score)
+
+        self.penalty_: BasePenalty = self._penalty.clone()
+        self.penalty_.fit(X, self._change_score)
+
         return self
 
     def _transform_scores(self, X: pd.DataFrame | pd.Series) -> pd.Series:

--- a/skchange/change_detectors/pelt.py
+++ b/skchange/change_detectors/pelt.py
@@ -216,7 +216,8 @@ class PELT(BaseChangeDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="2*min_segment_length",
         )
-        self.penalty_ = self._penalty.fit(X, self._cost)
+        self.penalty_: BasePenalty = self._penalty.clone()
+        self.penalty_.fit(X, self._cost)
         return self
 
     def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:

--- a/skchange/change_detectors/seeded_binseg.py
+++ b/skchange/change_detectors/seeded_binseg.py
@@ -221,7 +221,8 @@ class SeededBinarySegmentation(BaseChangeDetector):
             min_length=2 * self.min_segment_length,
             min_length_name="min_interval_length",
         )
-        self.penalty_ = self._penalty.fit(X, self._change_score)
+        self.penalty_: BasePenalty = self._penalty.clone()
+        self.penalty_.fit(X, self._change_score)
         return self
 
     def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:

--- a/skchange/compose/penalised_score.py
+++ b/skchange/compose/penalised_score.py
@@ -142,11 +142,11 @@ class PenalisedScore(BaseIntervalScorer):
         self.scorer.fit(X)
 
         if self.penalty.is_fitted:
-            if X.shape[1] != self.penalty.p:
+            if X.shape[1] != self.penalty.p_:
                 raise ValueError(
                     "The number of variables in the data must match the number of"
                     " variables in the penalty."
-                    f" 'X.shape[1]' = {X.shape[1]} and 'penalty.p' = {self.penalty.p}."
+                    f" 'X.shape[1]' = {X.shape[1]} and 'penalty.p' = {self.penalty.p_}."
                     " This error is most likely due to the penalty being fitted to a "
                     " different data set than the scorer."
                 )

--- a/skchange/compose/penalised_score.py
+++ b/skchange/compose/penalised_score.py
@@ -151,7 +151,7 @@ class PenalisedScore(BaseIntervalScorer):
                 raise ValueError(
                     "The number of variables in the data must match the number of"
                     " variables in the penalty."
-                    f" 'X.shape[1]' = {X.shape[1]} and 'penalty.p' = {self.penalty.p}."
+                    f" 'X.shape[1]' = {X.shape[1]} and 'penalty.p' = {self.penalty.p_}."
                     " This error is most likely due to the penalty being fitted to a "
                     " different data set than the scorer."
                 )

--- a/skchange/compose/penalised_score.py
+++ b/skchange/compose/penalised_score.py
@@ -1,5 +1,7 @@
 """Penalised interval scorer."""
 
+import copy
+
 import numpy as np
 
 from skchange.base import BaseIntervalScorer
@@ -142,17 +144,19 @@ class PenalisedScore(BaseIntervalScorer):
         self.scorer_: BaseIntervalScorer = self.scorer.clone()
         self.scorer_.fit(X)
 
-        self.penalty_: BasePenalty = self.penalty.clone()
-        if self.penalty_.is_fitted:
+        if self.penalty.is_fitted:
+            # Need to copy the penalty because a `clone` will not copy the fitted values
+            self.penalty_ = copy.deepcopy(self.penalty)
             if X.shape[1] != self.penalty_.p_:
                 raise ValueError(
                     "The number of variables in the data must match the number of"
                     " variables in the penalty."
-                    f" 'X.shape[1]' = {X.shape[1]} and 'penalty.p' = {self.penalty.p_}."
+                    f" 'X.shape[1]' = {X.shape[1]} and 'penalty.p' = {self.penalty.p}."
                     " This error is most likely due to the penalty being fitted to a "
                     " different data set than the scorer."
                 )
         else:
+            self.penalty_: BasePenalty = self.penalty.clone()
             self.penalty_.fit(X, self.scorer_)
 
         if self.penalty.penalty_type == "constant" or X.shape[1] == 1:

--- a/skchange/penalties/base.py
+++ b/skchange/penalties/base.py
@@ -62,10 +62,10 @@ class BasePenalty(BaseEstimator):
             Reference to a fitted instance of self.
         """
         X = as_2d_array(X)
-        self.n = X.shape[0]
-        self.p = X.shape[1]
-        self.n_params_total = scorer.get_param_size(self.p)
-        self.n_params_per_variable = scorer.get_param_size(1)
+        self.n_ = X.shape[0]
+        self.p_ = X.shape[1]
+        self.n_params_total_ = scorer.get_param_size(self.p_)
+        self.n_params_per_variable_ = scorer.get_param_size(1)
 
         self._fit(X=X, scorer=scorer)
 

--- a/skchange/penalties/constant_penalties.py
+++ b/skchange/penalties/constant_penalties.py
@@ -83,7 +83,7 @@ class BICPenalty(BasePenalty):
             Shape ``(1,)`` array with the base (unscaled) penalty values.
         """
         # +1 due to the additional change point parameter in the model.
-        base_penalty = (self.n_params_total + 1) * np.log(self.n)
+        base_penalty = (self.n_params_total_ + 1) * np.log(self.n_)
         return base_penalty
 
     @classmethod
@@ -148,9 +148,9 @@ class ChiSquarePenalty(BasePenalty):
         base_values : np.ndarray
             Shape ``(1,)`` array with the base (unscaled) penalty values.
         """
-        psi = np.log(self.n)
+        psi = np.log(self.n_)
         base_penalty = (
-            self.n_params_total + 2 * np.sqrt(self.n_params_total * psi) + 2 * psi
+            self.n_params_total_ + 2 * np.sqrt(self.n_params_total_ * psi) + 2 * psi
         )
         return base_penalty
 

--- a/skchange/penalties/linear_penalties.py
+++ b/skchange/penalties/linear_penalties.py
@@ -31,7 +31,7 @@ class LinearPenalty(BasePenalty):
             the array is the base penalty value for ``i+1`` variables being affected by
             the change. The base penalty array is non-decreasing.
         """
-        return self.intercept + self.slope * np.arange(1, self.p + 1)
+        return self.intercept + self.slope * np.arange(1, self.p_ + 1)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -95,9 +95,9 @@ class LinearChiSquarePenalty(BasePenalty):
             the array is the base penalty value for ``i+1`` variables being affected by
             the change. The base penalty array is non-decreasing.
         """
-        psi = np.log(self.n)
-        component_penalty = 2 * np.log(self.n_params_per_variable * self.p)
-        base_penalties = 2 * psi + 2 * np.cumsum(np.full(self.p, component_penalty))
+        psi = np.log(self.n_)
+        component_penalty = 2 * np.log(self.n_params_per_variable_ * self.p_)
+        base_penalties = 2 * psi + 2 * np.cumsum(np.full(self.p_, component_penalty))
         return base_penalties
 
     @classmethod

--- a/skchange/penalties/nonlinear_penalties.py
+++ b/skchange/penalties/nonlinear_penalties.py
@@ -167,14 +167,14 @@ class NonlinearChiSquarePenalty(BasePenalty):
         self
             Reference to self.
         """
-        if self.n_params_per_variable > 2:
+        if self.n_params_per_variable_ > 2:
             raise ValueError(
                 "NonlinearChiSquarePenalty can only be used with scorers that have at"
                 " most 2 parameters per variable (scorer.get_param_size(1) <= 2)"
             )
 
         self._base_penalty_values = self._make_penalty(
-            self.n, self.p, self.n_params_per_variable
+            self.n_, self.p_, self.n_params_per_variable_
         )
         return self
 

--- a/skchange/penalties/tests/test_minimum_penalty.py
+++ b/skchange/penalties/tests/test_minimum_penalty.py
@@ -20,7 +20,7 @@ def test_minimum_penalty_initialization():
     penalty = MinimumPenalty([penalty1, penalty2], scale=1.0)
     penalty.fit(df, scorer)
     assert penalty.penalty_type == "linear"
-    assert penalty.p == df.shape[1]
+    assert penalty.p_ == df.shape[1]
 
 
 def test_minimum_penalty_invalid_initialization():
@@ -60,4 +60,4 @@ def test_minimum_penalty_nonlinear():
     penalty = MinimumPenalty([penalty1, penalty2], scale=1.0)
     penalty.fit(df, scorer)
     assert penalty.penalty_type == "nonlinear"
-    assert penalty.p == df.shape[1]
+    assert penalty.p_ == df.shape[1]

--- a/skchange/penalties/tests/test_nonlinear_penalties.py
+++ b/skchange/penalties/tests/test_nonlinear_penalties.py
@@ -54,6 +54,6 @@ def test_nonlinear_chisquare_too_many_params():
     penalty = NonlinearChiSquarePenalty(scale=1.0)
     X = np.random.rand(100, 3)
     scorer = CUSUM()
-    penalty.n_params_per_variable = 3
+    penalty.n_params_per_variable_ = 3
     with pytest.raises(ValueError):
         penalty._fit(X, scorer)

--- a/skchange/penalties/tests/test_penalties.py
+++ b/skchange/penalties/tests/test_penalties.py
@@ -35,7 +35,7 @@ def test_values(Penalty: BasePenalty):
     if penalty.penalty_type == "constant":
         assert penalty.values.shape == (1,)
     else:
-        assert penalty.values.shape == (penalty.p,)
+        assert penalty.values.shape == (penalty.p_,)
 
     # Penalties can have value = 0, but the test instances should have positive values.
     assert np.all(penalty.values > 0.0)


### PR DESCRIPTION
Fixes issues with fitted penalties. `get_fitted_params` previously showed both `_penalty` and `penalty_` as being fitted, and none of the interval fitted parameters.

Changes:
- Add underscore suffix to fitted attributes in penalties such that they show upon `get_fitted_params`.
- Clone `_penalty` to `penalty_` before fitting to avoid `_penalty` being fitted.