### PR TITLE
Rename get_param_size -> get_model_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ df = generate_anomalous_data(n, anomalies, means, random_state=3)
 p = df.shape[1]
 
 score = L2Saving()
-penalty = make_linear_chi2_penalty(score.get_param_size(1), n, p)
+penalty = make_linear_chi2_penalty(score.get_model_size(1), n, p)
 penalised_score = PenalisedScore(score, penalty)
 detector = CAPA(penalised_score, find_affected_components=True)
 detector.fit_predict(df)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,7 @@ Example
     p = df.shape[1]
 
     score = L2Saving()
-    penalty = make_linear_chi2_penalty(score.get_param_size(1), n, p)
+    penalty = make_linear_chi2_penalty(score.get_model_size(1), n, p)
     penalised_score = PenalisedScore(score, penalty)
     detector = CAPA(penalised_score, find_affected_components=True)
     detector.fit_predict(df)

--- a/extension_templates/change_score.py
+++ b/extension_templates/change_score.py
@@ -25,7 +25,7 @@ Mandatory implements:
 
 Optional implements:
     minimum size of interval  - min_size(self)
-    number of parameters      - get_param_size(self, p)
+    number of parameters      - get_model_size(self, p)
 
 Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
@@ -189,7 +189,7 @@ class MyChangeScore(BaseIntervalScorer):
 
     # todo: implement, optional, defaults to output p (one parameter per variable).
     # used for setting a decent default penalty in detectors.
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters estimated by the score in each segment.
 
         Parameters

--- a/extension_templates/cost.py
+++ b/extension_templates/cost.py
@@ -27,7 +27,7 @@ Optional implements:
     evaluating fixed param   - _evaluate_fixed_param(self, starts, ends)
     checking fixed param     - _check_fixed_param(self, param, X)
     minimum size of interval  - min_size(self)
-    number of parameters      - get_param_size(self, p)
+    number of parameters      - get_model_size(self, p)
 
 Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
@@ -237,7 +237,7 @@ class MyCost(BaseCost):
 
     # todo: implement, optional, defaults to output p (one parameter per variable).
     # used for setting a decent default penalty in detectors.
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/interactive/compare_detector_outputs.py
+++ b/interactive/compare_detector_outputs.py
@@ -41,7 +41,7 @@ print(anomaly_labels)
 # Subset segment anomaly detector
 score = L2Saving()
 p = df.shape[1]
-penalty = make_linear_chi2_penalty(score.get_param_size(p), n, p)
+penalty = make_linear_chi2_penalty(score.get_model_size(p), n, p)
 subset_anomaly_detector = CAPA(score, penalty, find_affected_components=True)
 subset_anomalies = subset_anomaly_detector.fit_predict(df)
 subset_anomaly_labels = subset_anomaly_detector.transform(df)

--- a/skchange/anomaly_detectors/_capa.py
+++ b/skchange/anomaly_detectors/_capa.py
@@ -131,14 +131,14 @@ def _make_chi2_penalty_from_score(score: BaseIntervalScorer) -> float:
     score.check_is_fitted()
     n = score._X.shape[0]
     p = score._X.shape[1]
-    return make_chi2_penalty(score.get_param_size(p), n)
+    return make_chi2_penalty(score.get_model_size(p), n)
 
 
 def _make_linear_chi2_penalty_from_score(score: BaseIntervalScorer) -> np.ndarray:
     score.check_is_fitted()
     n = score._X.shape[0]
     p = score._X.shape[1]
-    return make_linear_chi2_penalty(score.get_param_size(p), n, p)
+    return make_linear_chi2_penalty(score.get_model_size(p), n, p)
 
 
 def _check_capa_penalised_score(score: BaseIntervalScorer, name: str, caller_name: str):
@@ -412,7 +412,7 @@ class CAPA(BaseSegmentAnomalyDetector):
             score.check_is_fitted()
             n = score._X.shape[0]
             p = score._X.shape[1]
-            return make_nonlinear_chi2_penalty(score.get_param_size(p), n, p)
+            return make_nonlinear_chi2_penalty(score.get_model_size(p), n, p)
 
         params = [
             {

--- a/skchange/anomaly_detectors/_circular_binseg.py
+++ b/skchange/anomaly_detectors/_circular_binseg.py
@@ -109,7 +109,7 @@ def _make_bic_penalty_from_score(score: BaseIntervalScorer) -> float:
     score.check_is_fitted()
     n = score._X.shape[0]
     p = score._X.shape[1]
-    return make_bic_penalty(score.get_param_size(p), n, additional_cpts=2)
+    return make_bic_penalty(score.get_model_size(p), n, additional_cpts=2)
 
 
 class CircularBinarySegmentation(BaseSegmentAnomalyDetector):

--- a/skchange/anomaly_detectors/tests/test_capa.py
+++ b/skchange/anomaly_detectors/tests/test_capa.py
@@ -24,7 +24,7 @@ def make_nonlinear_chi2_penalty_from_score(
     score.check_is_fitted()
     n = score._X.shape[0]
     p = score._X.shape[1]
-    return make_nonlinear_chi2_penalty(score.get_param_size(p), n, p)
+    return make_nonlinear_chi2_penalty(score.get_model_size(p), n, p)
 
 
 COSTS_AND_SAVINGS = COSTS + SAVINGS

--- a/skchange/anomaly_scores/_from_cost.py
+++ b/skchange/anomaly_scores/_from_cost.py
@@ -87,7 +87,7 @@ class Saving(BaseIntervalScorer):
         else:
             return self.optimised_cost.min_size
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the saving function.
 
         Defaults to 1 parameter per variable in the data. This method should be
@@ -100,9 +100,9 @@ class Saving(BaseIntervalScorer):
             Number of variables in the data.
         """
         if self.is_fitted:
-            return self.optimised_cost_.get_param_size(p)
+            return self.optimised_cost_.get_model_size(p)
         else:
-            return self.optimised_cost.get_param_size(p)
+            return self.optimised_cost.get_model_size(p)
 
     def _fit(self, X: np.ndarray, y=None):
         """Fit the saving scorer.
@@ -254,7 +254,7 @@ class LocalAnomalyScore(BaseIntervalScorer):
         else:
             return self.cost.min_size
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters to estimate over each interval.
 
         The primary use of this method is to determine an appropriate default penalty
@@ -266,9 +266,9 @@ class LocalAnomalyScore(BaseIntervalScorer):
             Number of variables in the data.
         """
         if self.is_fitted:
-            return self.interval_cost_.get_param_size(p)
+            return self.interval_cost_.get_model_size(p)
         else:
-            return self.cost.get_param_size(p)
+            return self.cost.get_model_size(p)
 
     def _fit(self, X: np.ndarray, y=None):
         """Fit the saving scorer.

--- a/skchange/base/_base_interval_scorer.py
+++ b/skchange/base/_base_interval_scorer.py
@@ -12,7 +12,7 @@ Needs to be implemented for a concrete interval scorer:
 
 Recommended but optional to implement for a concrete detector:
     min_size(self)
-    get_param_size(self, p)
+    get_model_size(self, p)
 """
 
 __author__ = ["Tveten", "johannvk", "fkiraly"]
@@ -220,8 +220,8 @@ class BaseIntervalScorer(BaseEstimator):
         """
         raise NotImplementedError("abstract method")
 
-    def get_param_size(self, p: int) -> int:
-        """Get the number of parameters to estimate over each interval.
+    def get_model_size(self, p: int) -> int:
+        """Get the number of model parameters to estimate for each interval.
 
         The primary use of this method is to determine an appropriate default penalty
         value in detectors. For example, a scorer for a change in mean has one

--- a/skchange/change_detectors/_pelt.py
+++ b/skchange/change_detectors/_pelt.py
@@ -130,7 +130,7 @@ class PELT(BaseChangeDetector):
     penalty : float, optional
         The penalty to use for the changepoint detection. It must be non-negative. If
         `None`, the penalty is set to
-        `make_bic_penalty(n=X.shape[0], n_params=cost.get_param_size(X.shape[1]))`,
+        `make_bic_penalty(n=X.shape[0], n_params=cost.get_model_size(X.shape[1]))`,
         where ``X`` is the input data to `predict`.
     min_segment_length : int, optional, default=2
         Minimum length of a segment.
@@ -232,7 +232,7 @@ class PELT(BaseChangeDetector):
         if self.penalty is None:
             self.fitted_penalty = make_bic_penalty(
                 n=X.shape[0],
-                n_params=self.fitted_cost.get_param_size(X.shape[1]),
+                n_params=self.fitted_cost.get_model_size(X.shape[1]),
             )
         else:
             self.fitted_penalty = self.penalty

--- a/skchange/change_detectors/_seeded_binseg.py
+++ b/skchange/change_detectors/_seeded_binseg.py
@@ -114,7 +114,7 @@ def run_seeded_binseg(
         )
         scores = penalised_score.evaluate(intervals)
         argmax = np.argmax(scores)
-        max_scores[i] = scores[argmax]
+        max_scores[i] = scores[argmax, 0]  # index 0 to get a scalar value
         argmax_scores[i] = splits[0] + argmax
 
     if selection_method == "greedy":

--- a/skchange/change_scores/_continuous_linear_trend_score.py
+++ b/skchange/change_scores/_continuous_linear_trend_score.py
@@ -338,7 +338,7 @@ class ContinuousLinearTrendScore(BaseIntervalScorer):
         """
         return 2  # Need at least 2 points to define a line
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/change_scores/_from_cost.py
+++ b/skchange/change_scores/_from_cost.py
@@ -68,7 +68,7 @@ class ChangeScore(BaseIntervalScorer):
         else:
             return self.cost.min_size
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters to estimate over each interval.
 
         The primary use of this method is to determine an appropriate default penalty
@@ -80,9 +80,9 @@ class ChangeScore(BaseIntervalScorer):
             Number of variables in the data.
         """
         if self.is_fitted:
-            return self.cost_.get_param_size(p)
+            return self.cost_.get_model_size(p)
         else:
-            return self.cost.get_param_size(p)
+            return self.cost.get_model_size(p)
 
     def _fit(self, X: np.ndarray, y=None):
         """Fit the change score.

--- a/skchange/change_scores/_multivariate_gaussian_score.py
+++ b/skchange/change_scores/_multivariate_gaussian_score.py
@@ -181,7 +181,7 @@ class MultivariateGaussianScore(BaseIntervalScorer):
         else:
             return None
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters to estimate over each interval.
 
         The primary use of this method is to determine an appropriate default penalty

--- a/skchange/compose/penalised_score.py
+++ b/skchange/compose/penalised_score.py
@@ -93,7 +93,7 @@ def _make_bic_penalty_from_score(score: BaseIntervalScorer) -> float:
     score.check_is_fitted()
     n = score._X.shape[0]
     p = score._X.shape[1]
-    return make_bic_penalty(score.get_param_size(p), n)
+    return make_bic_penalty(score.get_model_size(p), n)
 
 
 class PenalisedScore(BaseIntervalScorer):
@@ -133,7 +133,7 @@ class PenalisedScore(BaseIntervalScorer):
         A function to create a default penalty from the fitted `score`. The function
         must take a fitted `BaseIntervalScorer` and return a penalty value or
         array. If `None`, the default penalty is created using
-        ``make_bic_penalty(score.get_param_size(score._X.shape[1]), score._X.shape[0])``.
+        ``make_bic_penalty(score.get_model_size(score._X.shape[1]), score._X.shape[0])``.
 
     References
     ----------
@@ -271,7 +271,7 @@ class PenalisedScore(BaseIntervalScorer):
         else:
             return self.score.min_size
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters to estimate over each interval.
 
         The primary use of this method is to determine an appropriate default penalty
@@ -285,7 +285,7 @@ class PenalisedScore(BaseIntervalScorer):
         p : int
             Number of variables in the data.
         """
-        return self.score.get_param_size(p)
+        return self.score.get_model_size(p)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skchange/compose/tests/test_penalised_score.py
+++ b/skchange/compose/tests/test_penalised_score.py
@@ -37,8 +37,8 @@ def test_penalised_score_fit():
         penalised_score.fit(df3)
 
 
-def test_penalised_score_get_param_size():
+def test_penalised_score_get_model_size():
     scorer = CUSUM()
     penalised_score = PenalisedScore(scorer)
-    assert penalised_score.get_param_size(1) == scorer.get_param_size(1)
-    assert penalised_score.get_param_size(5) == scorer.get_param_size(5)
+    assert penalised_score.get_model_size(1) == scorer.get_model_size(1)
+    assert penalised_score.get_model_size(5) == scorer.get_model_size(5)

--- a/skchange/costs/_gaussian_cost.py
+++ b/skchange/costs/_gaussian_cost.py
@@ -165,7 +165,7 @@ class GaussianCost(BaseCost):
         """
         return 2
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/_laplace_cost.py
+++ b/skchange/costs/_laplace_cost.py
@@ -256,7 +256,7 @@ class LaplaceCost(BaseCost):
         # Need at least 2 samples to estimate the location and scale.
         return 2
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/_linear_regression_cost.py
+++ b/skchange/costs/_linear_regression_cost.py
@@ -320,7 +320,7 @@ class LinearRegressionCost(BaseCost):
         """
         return 1
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/_linear_trend_cost.py
+++ b/skchange/costs/_linear_trend_cost.py
@@ -446,7 +446,7 @@ class LinearTrendCost(BaseCost):
         """
         return 3
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/_multivariate_gaussian_cost.py
+++ b/skchange/costs/_multivariate_gaussian_cost.py
@@ -224,7 +224,7 @@ class MultivariateGaussianCost(BaseCost):
         else:
             return None
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/_multivariate_t_cost.py
+++ b/skchange/costs/_multivariate_t_cost.py
@@ -1190,7 +1190,7 @@ class MultivariateTCost(BaseCost):
         else:
             return None
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/_poisson_cost.py
+++ b/skchange/costs/_poisson_cost.py
@@ -262,7 +262,7 @@ class PoissonCost(BaseCost):
         # Need at least 1 sample to estimate the rate parameter
         return 1
 
-    def get_param_size(self, p: int) -> int:
+    def get_model_size(self, p: int) -> int:
         """Get the number of parameters in the cost function.
 
         Parameters

--- a/skchange/costs/tests/test_linear_regression_cost.py
+++ b/skchange/costs/tests/test_linear_regression_cost.py
@@ -112,11 +112,11 @@ def test_min_size_property():
     assert cost.min_size == 2  # 2 features
 
 
-def test_get_param_size():
-    """Test get_param_size method."""
+def test_get_model_size():
+    """Test get_model_size method."""
     cost = LinearRegressionCost(response_col="log_house_price")
     # Number of parameters is equal to number of variables
-    assert cost.get_param_size(5) == 4
+    assert cost.get_model_size(5) == 4
 
 
 def test_simple_linear_regression_cost_fixed_params():
@@ -133,7 +133,7 @@ def test_simple_linear_regression_cost_fixed_params():
     cost.fit(np.hstack((y.reshape(-1, 1), X)))
 
     # Test that number of parameters is equal to number of columns:
-    assert cost.get_param_size(3) == 2
+    assert cost.get_model_size(3) == 2
 
     # Evaluate on the entire interval
     starts = np.array([0])

--- a/skchange/costs/tests/test_linear_trend_cost.py
+++ b/skchange/costs/tests/test_linear_trend_cost.py
@@ -311,12 +311,12 @@ def test_linear_trend_cost_default_time():
     ), "Costs should be lower when split into segments"
 
 
-def test_get_param_size():
-    """Test get_param_size method."""
+def test_get_model_size():
+    """Test get_model_size method."""
     cost = LinearTrendCost()
     # For each column we need 2 parameters (slope and intercept)
-    assert cost.get_param_size(3) == 6  # 3 columns * 2 params
-    assert cost.get_param_size(1) == 2  # 1 column * 2 params
+    assert cost.get_model_size(3) == 6  # 3 columns * 2 params
+    assert cost.get_model_size(1) == 2  # 1 column * 2 params
 
 
 def test_indexed_trend_vs_explicit_time():
@@ -384,7 +384,7 @@ def test_linear_trend_cost_as_saving():
     # Create MVCAPA detector with LinearTrendCost as Saving
     n = df.shape[0]
     p = df.shape[1]
-    penalty = make_linear_chi2_penalty(trend_saving.get_param_size(p), n, p)
+    penalty = make_linear_chi2_penalty(trend_saving.get_model_size(p), n, p)
     detector = CAPA(
         segment_saving=trend_saving,
         segment_penalty=penalty,

--- a/skchange/tests/test_all_interval_scorers.py
+++ b/skchange/tests/test_all_interval_scorers.py
@@ -137,9 +137,9 @@ def test_scorer_min_size(Scorer: BaseIntervalScorer):
 @pytest.mark.parametrize("Scorer", INTERVAL_SCORERS)
 def test_scorer_param_size(Scorer: BaseIntervalScorer):
     scorer = Scorer.create_test_instance()
-    assert scorer.get_param_size(1) >= 0
+    assert scorer.get_model_size(1) >= 0
 
     skip_if_no_test_data(scorer)
     x = generate_anomalous_data()
     scorer.fit(x)
-    assert scorer.get_param_size(1) >= 0
+    assert scorer.get_model_size(1) >= 0


### PR DESCRIPTION
`get_param_size` is confusing due to inherited methods like `get_param_names`, `get_params` and `set_params`. In the scikit-learn ecosystem, `param` mostly (always?) refers to the inputs to `__init__`.

`get_model_size` is more appriopriate, because the method refers to the number of model parameters are estimated within each segment, for the model implied by the scorer.