### PR TITLE
Rename tag capability:identify_variables -> capability:variable_identifcation

### DIFF
--- a/docs/source/user_guide/concepts/interval_scores.ipynb
+++ b/docs/source/user_guide/concepts/interval_scores.ipynb
@@ -28,17 +28,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.86044396]])"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -62,17 +52,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.18612366]])"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from skchange.change_scores import CUSUM\n",
     "\n",
@@ -92,19 +72,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.18612366],\n",
-       "       [0.76651348],\n",
-       "       [0.52551144]])"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "score.evaluate([[0, 5, 10], [10, 12, 30], [60, 69, 71]])"
    ]

--- a/skchange/anomaly_detectors/_capa.py
+++ b/skchange/anomaly_detectors/_capa.py
@@ -304,7 +304,9 @@ class CAPA(BaseSegmentAnomalyDetector):
         check_larger_than(min_segment_length, max_segment_length, "max_segment_length")
 
         self.clone_tags(_segment_saving, ["distribution_type"])
-        self.set_tags(**{"capability:identify_variables": find_affected_components})
+        self.set_tags(
+            **{"capability:variable_identification": find_affected_components}
+        )
 
     def _predict(self, X: pd.DataFrame | pd.Series) -> pd.Series:
         """Detect events in test/deployment data.

--- a/skchange/anomaly_detectors/base.py
+++ b/skchange/anomaly_detectors/base.py
@@ -144,7 +144,7 @@ class BaseSegmentAnomalyDetector(BaseDetector):
         respectively.
         """
         # Cannot extract this from segment_anomalies as it may be an empty list.
-        if self.get_tag("capability:identify_variables"):
+        if self.get_tag("capability:variable_identification"):
             return self._format_sparse_output_icolumns(segment_anomalies, closed)
         else:
             return self._format_sparse_output_ilocs(segment_anomalies, closed)

--- a/skchange/base/_base_detector.py
+++ b/skchange/base/_base_detector.py
@@ -74,7 +74,7 @@ class BaseDetector(_BaseDetector):
         "capability:multivariate": True,
         "capability:missing_values": False,
         "capability:update": False,
-        "capability:identify_variables": False,
+        "capability:variable_identification": False,
         "distribution_type": "None",
         "X_inner_mtype": "pd.DataFrame",
         "fit_is_empty": False,

--- a/skchange/tests/test_all_detectors.py
+++ b/skchange/tests/test_all_detectors.py
@@ -14,7 +14,7 @@ ALL_DETECTORS = ANOMALY_DETECTORS + CHANGE_DETECTORS
 VALID_DETECTOR_TAGS = list(VALID_ESTIMATOR_TAGS) + [
     "task",
     "learning_type",
-    "capability:identify_variables",
+    "capability:variable_identification",
 ]
 
 


### PR DESCRIPTION
Rename tag "capability:identify_variables" -> "capability:variable_identifcation". To conform with `sktime`.