### PR TITLE
[MNT] Update codecov version in Github actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,11 +43,9 @@ jobs:
           python -m pip install .[test]
           pytest --cov --cov-report=xml --cov-report=term
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          files: ./coverage.xml
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   pytests-with-numba:
     name: pytests-with-numba
@@ -69,8 +67,6 @@ jobs:
           python -m pip install .[test,numba]
           pytest --cov --cov-report=xml --cov-append --cov-report=term
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          files: ./coverage.xml
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Issue: Codecov badge not loading properly in the readme.

Attempted solution: Update codecov version in CI as well as token.

Following https://docs.codecov.com/docs/codecov-tokens