### PR TITLE
[BUG] Remove duplicate calls to get_required_cut_size

### DIFF
--- a/skchange/base/_base_interval_scorer.py
+++ b/skchange/base/_base_interval_scorer.py
@@ -116,9 +116,6 @@ class BaseIntervalScorer(BaseEstimator):
 
         self._fit(X=self._X, y=y)
         self._is_fitted = True
-        # Store "required cut size", as its faster than looking
-        # it up through a tag every time `evaluate` is called.
-        self._required_cut_size = self._get_required_cut_size()
 
         return self
 


### PR DESCRIPTION
Issue: `_get_required_cut_size` was called twice in `BaseIntervalScorer.fit`.

FIx: Remove the latter call.