### PR TITLE
build: Add release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,78 @@
+name-template: 'Skchange $RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+exclude-labels:
+  - skip changelog
+  - release
+
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+replacers:
+  # Remove conventional commits from titles
+  - search: '/- (build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*\))?(\!)?\: /g'
+    replace: '- '
+
+autolabeler:
+  - label: breaking
+    title:
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*\))?\!\: /'
+  - label: build
+    title:
+      - '/^build/'
+  - label: internal
+    title:
+      - '/^(chore|ci|refactor|test)/'
+  - label: deprecation
+    title:
+      - '/^depr/'
+  - label: documentation
+    title:
+      - '/^docs/'
+  - label: enhancement
+    title:
+      - '/^feat/'
+  - label: fix
+    title:
+      - '/^fix/'
+  - label: performance
+    title:
+      - '/^perf/'
+  - label: release
+    title:
+      - '/^release/'
+
+categories:
+  - title: 🏆 Highlights
+    labels:
+      - highlight
+  - title: 💥 Breaking changes
+    labels:
+      - breaking
+  - title: ⚠️ Deprecations
+    labels:
+      - deprecation
+  - title: 🚀 Performance improvements
+    labels:
+      - performance
+  - title: ✨ Enhancements
+    labels:
+      - enhancement
+  - title: 🐞 Bug fixes
+    labels:
+      - fix
+  - title: 📖 Documentation
+    labels:
+      - documentation
+  - title: 📦 Build system
+    labels:
+      - build
+  - title: 🛠️ Other improvements
+    labels:
+      - internal
+
+template: |
+  $CHANGES
+
+  Thanks to all contributors!
+  $CONTRIBUTORS

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,7 @@ jobs:
             echo "Error: version not found in pyproject.toml"
             exit 1
           fi
+          echo "Got version: $VERSION"
           echo "$VERSION" > version.txt
 
       - name: Upload version artifact
@@ -172,6 +173,7 @@ jobs:
         id: github-release
         uses: release-drafter/release-drafter@v6
         with:
+          config-name: release-drafter.yml
           name: skchange v${{ steps.read_version.outputs.version }}
           tag: v${{ steps.read_version.outputs.version }}
           version: ${{ steps.read_version.outputs.version }}


### PR DESCRIPTION
Issue: The release workflow cannot complete without a release-drafter config file: https://github.com/NorskRegnesentral/skchange/actions/runs/17499240625/job/49707959320

Solution: This PR adds such a config based on a similar file in Polars: https://github.com/pola-rs/polars/blob/main/.github/release-drafter-python.yml