### PR TITLE
ci: Publish draft at the end of release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,6 +183,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish GitHub release
-        run: gh release edit v${{ steps.read_version.outputs.version }} --draft=true
+        run: gh release edit v${{ steps.read_version.outputs.version }} --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Until now, the draft hasn't been published automatically due to running the procedure in and fixing bugs. Now it seems to work as it should, so we turn on automatic publication.